### PR TITLE
Fix bug with MultiTableAliasRule and CTE

### DIFF
--- a/TSQLLINT_TESTS/UnitTests/Rules/multi-table-alias/multi-table-alias-no-error.sql
+++ b/TSQLLINT_TESTS/UnitTests/Rules/multi-table-alias/multi-table-alias-no-error.sql
@@ -6,3 +6,23 @@ JOIN Purchasing.Vendor v
 	ON pv.BusinessEntityID = v.BusinessEntityID
 WHERE ProductSubcategoryID = 15
 ORDER BY v.Name;
+GO;
+
+-- CTE's should not require alias
+WITH MY_CTE (Foo, Bar)
+AS (
+	SELECT FooBars.Foo,
+		FooCars.Bar
+	FROM dbo.FooBars AS FooBars WITH (NOLOCK)
+	LEFT JOIN dbo.FooCars AS FooCars
+		ON Foobars.Foo = FooCars.Foo
+)
+
+SELECT *
+FROM (
+	SELECT *
+	FROM dbo.SomeTable AS SomeTable WITH (NOLOCK)
+	INNER JOIN MY_CTE  --multi-table-alias error here
+		ON MYCTE.Foo = SomeTable.Foo
+	WHERE SomeTable.ID < 5
+) AS JoinedTable


### PR DESCRIPTION
Scripts containing common table expressions were being
flagged as violating the Multi Table Alias rule.

* Add new CTE Rulevisitor to capture CTE Names
* Pass List of CTE Names to Table Alias Visitor

Resolves #9 