### PR TITLE
Fix syntax error to show "error" instead of "off"

### DIFF
--- a/TSQLLINT_LIB/Parser/SqlRuleVisitor.cs
+++ b/TSQLLINT_LIB/Parser/SqlRuleVisitor.cs
@@ -27,7 +27,7 @@ namespace TSQLLINT_LIB.Parser
 
             if (errors.Count > 0)
             {
-                Violations.Add(new RuleViolation(sqlPath, "TSQL not syntactically correct"));
+                Violations.Add(new RuleViolation(sqlPath, null, "TSQL not syntactically correct", 0, 0, RuleViolationSeverity.Error));
                 return;
             }
 

--- a/TSQLLINT_LIB/Rules/RuleViolations/RuleViolation.cs
+++ b/TSQLLINT_LIB/Rules/RuleViolations/RuleViolation.cs
@@ -25,11 +25,5 @@
             Line = startLine;
             Column = startColumn;
         }
-
-        public RuleViolation(string fileName, string text)
-        {
-            FileName = fileName;
-            Text = text;
-        }
     }
 }

--- a/TSQLLINT_TESTS/IntegrationTests/integration-tests.cs
+++ b/TSQLLINT_TESTS/IntegrationTests/integration-tests.cs
@@ -61,7 +61,7 @@ namespace TSQLLINT_LIB_TESTS.IntegrationTests
 
         private static readonly List<RuleViolation> TestFileInvalidSyntaxRuleViolations = new List<RuleViolation>
         {
-            new RuleViolation(null, "TSQL not syntactically correct")
+            new RuleViolation(null, null, "TSQL not syntactically correct", 0, 0, RuleViolationSeverity.Error)
         };
 
         private static readonly List<RuleViolation> TestFileOneRuleViolations = new List<RuleViolation>


### PR DESCRIPTION
This fixes an issue where a SQL syntax error would show the type of error as "off".