### PR TITLE
Remove the NuGet IP from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,6 @@ clone_depth: 5                      # clone entire repository history if not def
 cache:
   - C:\Users\appveyor\AppData\Local\NuGet\Cache
 
-hosts:
-  api.nuget.org: 93.184.221.200
-
 #---------------------------------#
 #       build configuration       #
 #---------------------------------#


### PR DESCRIPTION
The AppVeyor file had a specific IP for NuGet, but AFAIK there is not necessary and looks like it was really a workaround for a long ago issue.