### PR TITLE
Cache the final NuGet package installed files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ clone_depth: 5                      # clone entire repository history if not def
 
 # cache nuget packages
 cache:
-  - C:\Users\appveyor\AppData\Local\NuGet\Cache
+  - packages -> **\packages.config
 
 #---------------------------------#
 #       build configuration       #


### PR DESCRIPTION
I read this was the recommended way to cache for NuGet and actually prevents any access to the NuGet hosts unless there was a dependency change.