### PR TITLE
Fix references to APPDATA

### DIFF
--- a/scripts/install/install.js
+++ b/scripts/install/install.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 const execSync = require('child_process').execSync;
 
 // calls powershell script to install missing dependencies
-execSync(`call ${process.env.APPDATA}/npm/node_modules/tsqllint/scripts/install/install-dependencies.cmd`);
+execSync(`call ${__dirname}/install-dependencies.cmd`);
 
 // copy patched version of tsqllint script
-fs.createReadStream('./scripts/install/tsqllint').pipe(fs.createWriteStream(`${process.env.APPDATA}/npm/tsqllint`))
+fs.createReadStream(`${__dirname}/tsqllint`).pipe(fs.createWriteStream(`${process.env.npm_config_prefix}/tsqllint`))


### PR DESCRIPTION
Mr. Jaxon wasn't able to install this on his machine because the global Node.js directory is in Program Files. Fixing up the fixed APPDATA references to use the configured npm prefix will get it working better out of the box for folks :)