### PR TITLE
Update semicolon rule to correctly parse subqueries in create statements

### DIFF
--- a/TSQLLINT_LIB/Parser/RuleVisitorBuilder.cs
+++ b/TSQLLINT_LIB/Parser/RuleVisitorBuilder.cs
@@ -13,7 +13,7 @@ namespace TSQLLINT_LIB.Parser
     {
         private readonly IReporter Reporter;
         private readonly IConfigReader ConfigReader;
-        private readonly List<Type> RuleVisitors = new List<Type>()
+        public readonly List<Type> RuleVisitorTypes = new List<Type>()
         {
             typeof(ConditionalBeginEndRule),
             typeof(DataCompressionOptionRule),
@@ -44,9 +44,9 @@ namespace TSQLLINT_LIB.Parser
         public List<TSqlFragmentVisitor> BuildVisitors(string sqlPath, List<RuleViolation> violations)
         {
             var configuredVisitors = new List<TSqlFragmentVisitor>();
-            for (var index = 0; index < RuleVisitors.Count; index++)
+            for (var index = 0; index < RuleVisitorTypes.Count; index++)
             {
-                var visitor = RuleVisitors[index];
+                var visitor = RuleVisitorTypes[index];
                 Action<string, string, int, int> ErrorCallback = delegate(string ruleName, string ruleText, int startLne, int startColumn)
                 {
                     Reporter.ReportViolation(new RuleViolation(

--- a/TSQLLINT_LIB/Parser/SqlRuleVisitor.cs
+++ b/TSQLLINT_LIB/Parser/SqlRuleVisitor.cs
@@ -33,9 +33,10 @@ namespace TSQLLINT_LIB.Parser
                 return;
             }
 
-            for (var index = 0; index < RuleVisitorBuilder.BuildVisitors(sqlPath, Violations).Count; index++)
+            var ruleVisitors = RuleVisitorBuilder.BuildVisitors(sqlPath, Violations);
+            for (var index = 0; index < ruleVisitors.Count; index++)
             {
-                var visitor = RuleVisitorBuilder.BuildVisitors(sqlPath, Violations)[index];
+                var visitor = ruleVisitors[index];
                 sqlFragment.Accept(visitor);
             }
         }

--- a/TSQLLINT_TESTS/TSQLLINT_LIB_TESTS.csproj
+++ b/TSQLLINT_TESTS/TSQLLINT_LIB_TESTS.csproj
@@ -100,6 +100,7 @@
     <Content Include="UnitTests\Rules\multi-table-alias\multi-table-alias-no-error.sql" />
     <Content Include="UnitTests\Rules\multi-table-alias\multi-table-alias-one-error-with-tabs.sql" />
     <Content Include="UnitTests\Rules\multi-table-alias\multi-table-alias-multiple-errors-with-tabs.sql" />
+    <Content Include="UnitTests\Rules\semicolon-termination\semicolon-termination-no-error-create-object.sql" />
     <Content Include="UnitTests\Rules\set-variable\set-variable-no-error.sql" />
     <Content Include="UnitTests\Rules\set-variable\set-variable-one-error-mixed-state.sql" />
     <Content Include="UnitTests\Rules\set-variable\set-variable-one-error.sql" />

--- a/TSQLLINT_TESTS/UnitTests/Rules/rule-tests.cs
+++ b/TSQLLINT_TESTS/UnitTests/Rules/rule-tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
@@ -226,6 +226,7 @@ namespace TSQLLINT_LIB_TESTS.UnitTests.Rules
           {
               new RuleViolation(ruleName: "semicolon-termination", startLine: 1, startColumn: 18)
           }},
+          new object[] {"semicolon-termination", "semicolon-termination-no-error-create-object", typeof(SemicolonTerminationRule), new List<RuleViolation>{}},
           new object[] {"semicolon-termination", "semicolon-termination-multiple-errors-with-tab", typeof(SemicolonTerminationRule), new List<RuleViolation>
           {
               new RuleViolation(ruleName: "semicolon-termination", startLine: 2, startColumn: 24),

--- a/TSQLLINT_TESTS/UnitTests/Rules/semicolon-termination/semicolon-termination-no-error-create-object.sql
+++ b/TSQLLINT_TESTS/UnitTests/Rules/semicolon-termination/semicolon-termination-no-error-create-object.sql
@@ -1,0 +1,36 @@
+CREATE TABLE dbo.t1 (
+	Id INT,
+	Name VARCHAR(64)
+);
+
+CREATE TABLE dbo.t2 (
+	Id INT,
+	Name VARCHAR(64)
+);
+GO
+
+CREATE VIEW dbo.TestView
+AS
+  SELECT
+	t1.Id AS t1_id,
+	t1.Name AS t1_name
+  FROM t1
+  LEFT JOIN t2 ON t1.Id = t2.Id;
+GO
+
+CREATE FUNCTION dbo.GetId (@name varchar(64))  
+RETURNS int  
+WITH EXECUTE AS CALLER  
+AS  
+BEGIN;
+	DECLARE @returnVal int;
+	SELECT @returnVal = t1.Id FROM t1 where t1.name = @name;
+	RETURN @returnValue;
+END;
+GO;
+
+DROP VIEW dbo.TestView;
+DROP FUNCTION dbo.GetId;
+DROP TABLE t1;
+DROP TABLE t2;
+GO;


### PR DESCRIPTION
  - Add test for create view and create function statements
  - Update rule to allow for semicolons following subquery fragments
  - Resolves #43 