### PR TITLE
Init/Force changes

### DIFF
--- a/TSQLLint.Tests/UnitTests/CommandLineOptions/CommandLineOptionHandlerTest.cs
+++ b/TSQLLint.Tests/UnitTests/CommandLineOptions/CommandLineOptionHandlerTest.cs
@@ -107,6 +107,7 @@ namespace TSQLLint.Tests.UnitTests.CommandLineOptions
             Assert.IsFalse(performLinting);
             Assert.AreEqual(".tsqllintrc", info.Options.ConfigFile);
             Assert.IsTrue(info.ConfigFileGenerator.ConfigFilePathsWritten.Contains(".tsqllintrc"));
+            Assert.AreEqual(0, info.Reporter.Messages.Count);
         }
 
         [Test]
@@ -122,6 +123,7 @@ namespace TSQLLint.Tests.UnitTests.CommandLineOptions
             Assert.IsFalse(performLinting);
             Assert.AreEqual("custom.config", info.Options.ConfigFile);
             Assert.IsTrue(info.ConfigFileGenerator.ConfigFilePathsWritten.Contains("custom.config"));
+            Assert.AreEqual(0, info.Reporter.Messages.Count);
         }
 
         [Test]
@@ -152,6 +154,7 @@ namespace TSQLLint.Tests.UnitTests.CommandLineOptions
             Assert.IsFalse(performLinting);
             Assert.AreEqual(".tsqllintrc", info.Options.ConfigFile);
             Assert.IsTrue(info.ConfigFileGenerator.ConfigFilePathsWritten.Contains(".tsqllintrc"));
+            Assert.AreEqual(0, info.Reporter.Messages.Count);
         }
 
         [Test]
@@ -167,6 +170,7 @@ namespace TSQLLint.Tests.UnitTests.CommandLineOptions
             Assert.IsFalse(performLinting);
             Assert.AreEqual("custom.config", info.Options.ConfigFile);
             Assert.IsTrue(info.ConfigFileGenerator.ConfigFilePathsWritten.Contains("custom.config"));
+            Assert.AreEqual(0, info.Reporter.Messages.Count);
         }
 
         [Test]
@@ -182,6 +186,7 @@ namespace TSQLLint.Tests.UnitTests.CommandLineOptions
             Assert.IsFalse(performLinting);
             Assert.AreEqual(".tsqllintrc", info.Options.ConfigFile);
             Assert.IsTrue(info.ConfigFileGenerator.ConfigFilePathsWritten.Contains(".tsqllintrc"));
+            Assert.AreEqual(0, info.Reporter.Messages.Count);
         }
 
         [Test]
@@ -197,6 +202,7 @@ namespace TSQLLint.Tests.UnitTests.CommandLineOptions
             Assert.IsFalse(performLinting);
             Assert.AreEqual("custom.config", info.Options.ConfigFile);
             Assert.IsTrue(info.ConfigFileGenerator.ConfigFilePathsWritten.Contains("custom.config"));
+            Assert.AreEqual(0, info.Reporter.Messages.Count);
         }
 
         private static TestObjects SetupHandler(string[] args, bool shouldFindFile = true, string defaultConfigFile = ".tsqllintrc")


### PR DESCRIPTION
If just init or force is used as options and a config file is created/replaced then help will no longer be displayed