### PR TITLE
Ability to list plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ tsqllint file_one.sql file_two.sql "c:\database scripts"
 $ tsqllint c:\database_scripts\file*.sql
 
 # print path to .tsqllintrc config file
-$ tsqllint --print
+$ tsqllint --print-config
 
 # display usage info
 $ tsqllint --help
@@ -104,6 +104,9 @@ Once you complete your plugin, update your .tsqllintrc file to point to your ass
     }
 }
 ```
+
+# list the plugins loaded
+$ tsqllint --list-plugins
 
 This sample plugin notifies users that spaces should be used rather than tabs.
 

--- a/TSQLLint.Console/Application.cs
+++ b/TSQLLint.Console/Application.cs
@@ -1,5 +1,6 @@
 using TSQLLint.Common;
 using TSQLLint.Console.ConfigHandler;
+using TSQLLint.Lib.Config;
 
 namespace TSQLLint.Console
 {
@@ -28,8 +29,19 @@ namespace TSQLLint.Console
                 return;
             }
 
+            // read config
+            var configReader = new ConfigReader(_reporter);
+            configReader.LoadConfig(commandLineOptions.ConfigFile, commandLineOptions.DefaultConfigRules);
+
+            // display list of plugins
+            if (commandLineOptions.ListPlugins)
+            {
+                configReader.ListPlugins();
+                return;
+            }
+
             // perform lint
-            var lintingHandler = new LintingHandler(commandLineOptions, _reporter);
+            var lintingHandler = new LintingHandler(commandLineOptions, configReader, _reporter);
             lintingHandler.Lint();
 
             _reporter.ReportResults(_timer.Stop(), lintingHandler.LintedFileCount);

--- a/TSQLLint.Console/ConfigHandler/CommandLineOptionHandler.cs
+++ b/TSQLLint.Console/ConfigHandler/CommandLineOptionHandler.cs
@@ -52,7 +52,7 @@ namespace TSQLLint.Console.ConfigHandler
                 return false;
             }
 
-            if (_commandLineOptions.LintPath.Count >= 1)
+            if (_commandLineOptions.LintPath.Count >= 1 || _commandLineOptions.ListPlugins)
             {
                 return true;
             }

--- a/TSQLLint.Console/ConfigHandler/CommandLineOptions.cs
+++ b/TSQLLint.Console/ConfigHandler/CommandLineOptions.cs
@@ -44,6 +44,13 @@ namespace TSQLLint.Console.ConfigHandler
         TSQLLintOption(NonLintingCommand = true)]
         public bool PrintConfig { get; set; }
 
+        [Option('l',
+             longName: "list-plugins",
+             Required = false,
+             HelpText = "List the loaded plugins"),
+         TSQLLintOption(NonLintingCommand = true)]
+        public bool ListPlugins { get; set; }
+
         [Option('v',
             longName: "version",
             Required = false,

--- a/TSQLLint.Console/LintingHandler.cs
+++ b/TSQLLint.Console/LintingHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using TSQLLint.Common;
 using TSQLLint.Console.ConfigHandler;
 using TSQLLint.Lib.Config;
@@ -8,29 +9,26 @@ namespace TSQLLint.Console
 {
     public class LintingHandler
     {
-        private readonly SqlFileProcessor Parser;
+        private readonly SqlFileProcessor _parser;
 
-        private readonly CommandLineOptions CommandLineOptions;
+        private readonly CommandLineOptions _commandLineOptions;
 
         public int LintedFileCount { get; private set; }
 
-        public LintingHandler(CommandLineOptions commandLineOptions, IReporter reporter)
+        public LintingHandler(CommandLineOptions commandLineOptions, ConfigReader configReader, IReporter reporter)
         {
-            CommandLineOptions = commandLineOptions;
-
-            var configReader = new ConfigReader(reporter);
-            configReader.LoadConfig(commandLineOptions.ConfigFile, commandLineOptions.DefaultConfigRules);
+            _commandLineOptions = commandLineOptions;
 
             var pluginHandler = new PluginHandler(reporter, configReader.GetPlugins());
 
             var ruleVisitor = new SqlRuleVisitor(configReader, reporter);
-            Parser = new SqlFileProcessor(pluginHandler, ruleVisitor, reporter);
+            _parser = new SqlFileProcessor(pluginHandler, ruleVisitor, reporter);
         }
 
         public void Lint()
         {
-            Parser.ProcessList(CommandLineOptions.LintPath);
-            LintedFileCount = Parser.FileCount;
+            _parser.ProcessList(_commandLineOptions.LintPath);
+            LintedFileCount = _parser.FileCount;
         }
     }
 }

--- a/TSQLLint.Tests/IntegrationTests/ExistingConfigTests.cs
+++ b/TSQLLint.Tests/IntegrationTests/ExistingConfigTests.cs
@@ -16,11 +16,12 @@ namespace TSQLLint.Tests.IntegrationTests
         private static readonly string TestFileTwo = Path.Combine(TestFileDirectory, @"TestFileSubDirectory\integration-test-two.sql");
         private static readonly string TestFileInvalidSyntax = Path.Combine(TestFileDirectory, @"invalid-syntax.sql");
 
-        private static readonly string _ConfigNotFoundMessage = $"Config file not found at: {InvalidConfigFile} use the '--init' option to create if one does not exist or the '--force' option to overwrite";
-        private static readonly string _ConfigFoundMessage = $"Config file found at: {Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.tsqllintrc";
+        private static readonly string ConfigNotFoundMessage = $"Config file not found at: {InvalidConfigFile} use the '--init' option to create if one does not exist or the '--force' option to overwrite";
+        private static readonly string ConfigFoundMessage = $"Config file found at: {Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.tsqllintrc";
+        private static readonly string NoPluginsFound = "Did not find any plugins";
 
-        private static List<RuleViolation> _AllRuleViolations;
-        private static List<RuleViolation> _MultiFileRuleViolations;
+        private static List<RuleViolation> _allRuleViolations;
+        private static List<RuleViolation> _multiFileRuleViolations;
             
         private static string UsageString => new CommandLineOptions(new string[0]).GetUsage();
 
@@ -38,16 +39,16 @@ namespace TSQLLint.Tests.IntegrationTests
         {
             get
             {
-                if (_MultiFileRuleViolations != null)
+                if (_multiFileRuleViolations != null)
                 {
-                    return _MultiFileRuleViolations;
+                    return _multiFileRuleViolations;
                 }
                 
-                _MultiFileRuleViolations = new List<RuleViolation>();
-                _MultiFileRuleViolations.AddRange(TestFileOneRuleViolations);
-                _MultiFileRuleViolations.AddRange(TestFileTwoRuleViolations);
+                _multiFileRuleViolations = new List<RuleViolation>();
+                _multiFileRuleViolations.AddRange(TestFileOneRuleViolations);
+                _multiFileRuleViolations.AddRange(TestFileTwoRuleViolations);
 
-                return _MultiFileRuleViolations;
+                return _multiFileRuleViolations;
             }
         }
 
@@ -56,12 +57,12 @@ namespace TSQLLint.Tests.IntegrationTests
             get
             {
                 // change if used more than once
-                _AllRuleViolations = new List<RuleViolation>();
-                _AllRuleViolations.AddRange(TestFileOneRuleViolations);
-                _AllRuleViolations.AddRange(TestFileTwoRuleViolations);
-                _AllRuleViolations.AddRange(TestFileInvalidSyntaxRuleViolations);
+                _allRuleViolations = new List<RuleViolation>();
+                _allRuleViolations.AddRange(TestFileOneRuleViolations);
+                _allRuleViolations.AddRange(TestFileTwoRuleViolations);
+                _allRuleViolations.AddRange(TestFileInvalidSyntaxRuleViolations);
 
-                return _AllRuleViolations;
+                return _allRuleViolations;
             }
         }
 
@@ -73,12 +74,13 @@ namespace TSQLLint.Tests.IntegrationTests
                 yield return new TestCaseData(new List<string>(), UsageString, new List<RuleViolation>(), 0).SetName("Invalid No Args");
                 yield return new TestCaseData(new List<string> { string.Empty }, UsageString, new List<RuleViolation>(), 0).SetName("File Args Invalid No Files");
 
-                // args and lintging targets
+                // args and linting targets
                 yield return new TestCaseData(new List<string> { "-c", ValidConfigFile }, UsageString, new List<RuleViolation>(), 0).SetName("Config Args Valid No Lint Path");
-                yield return new TestCaseData(new List<string> { "-c", InvalidConfigFile }, _ConfigNotFoundMessage, new List<RuleViolation>(), 0).SetName("Config Args Invalid No Lint Path");
-                yield return new TestCaseData(new List<string> { "-c", InvalidConfigFile, TestFileOne }, _ConfigNotFoundMessage, new List<RuleViolation>(), 1).SetName("Config Args Invalid Lint Path");
+                yield return new TestCaseData(new List<string> { "-c", InvalidConfigFile }, ConfigNotFoundMessage, new List<RuleViolation>(), 0).SetName("Config Args Invalid No Lint Path");
+                yield return new TestCaseData(new List<string> { "-c", InvalidConfigFile, TestFileOne }, ConfigNotFoundMessage, new List<RuleViolation>(), 1).SetName("Config Args Invalid Lint Path");
                 yield return new TestCaseData(new List<string> { "-c", Path.Combine(TestFileDirectory, @".tsqllintrc"), TestFileOne }, null, TestFileOneRuleViolations, 1).SetName("Config Args Valid Lint One File");
-                yield return new TestCaseData(new List<string> { "-p" }, _ConfigFoundMessage, new List<RuleViolation>(), 0).SetName("Print Config Valid");
+                yield return new TestCaseData(new List<string> { "-p" }, ConfigFoundMessage, new List<RuleViolation>(), 0).SetName("Print Config Valid");
+                yield return new TestCaseData(new List<string> { "-l" }, NoPluginsFound, new List<RuleViolation>(), 0).SetName("List Plugins Valid");
                 yield return new TestCaseData(new List<string> { "-v" }, $"v{TSqllVersion}", new List<RuleViolation>(), 0).SetName("Print Version Valid");
                 yield return new TestCaseData(new List<string> { "-i", TestFileOne }, null, TestFileOneRuleViolations, 1).SetName("Init Args Valid Missing Config File");
                 yield return new TestCaseData(new List<string> { "-i", TestFileOne }, null, TestFileOneRuleViolations, 1).SetName("Init Args Valid Existing Config File");

--- a/TSQLLint.Tests/UnitTests/CommandLineOptions/CommandLineOptionHandlerTest.cs
+++ b/TSQLLint.Tests/UnitTests/CommandLineOptions/CommandLineOptionHandlerTest.cs
@@ -65,6 +65,20 @@ namespace TSQLLint.Tests.UnitTests.CommandLineOptions
         }
 
         [Test]
+        public void Passes_Handle_Config_Options_If_Listing_Plugins()
+        {
+            // arrange
+            var info = SetupHandler(new[] { "-l" });
+            
+            // act
+            var performLinting = info.Handler.HandleCommandLineOptions();
+
+            // assert
+            Assert.IsTrue(performLinting);
+            Assert.AreEqual(0, info.Reporter.Messages.Count);
+        }
+
+        [Test]
         public void Returns_In_Memory_Config_If_Missing_Config_File_When_None_Passed_And_No_Options()
         {
             // arrange

--- a/TSQLLint.Tests/UnitTests/Config/ConfigReaderTests.cs
+++ b/TSQLLint.Tests/UnitTests/Config/ConfigReaderTests.cs
@@ -27,10 +27,13 @@ namespace TSQLLint.Tests.UnitTests.Config
             // act
             var configReader = new ConfigReader(reporter, fileSystem);
             configReader.LoadConfig(null, defaultConfigFile);
+            configReader.ListPlugins();
 
             // assert
             Assert.AreEqual(RuleViolationSeverity.Error, configReader.GetRuleSeverity("select-star"));
             Assert.AreEqual(RuleViolationSeverity.Warning, configReader.GetRuleSeverity("statement-semicolon-termination"));
+            Assert.IsTrue(configReader.IsConfigLoaded);
+            reporter.Received().Report("Did not find any plugins");
         }
 
         [Test]
@@ -48,6 +51,7 @@ namespace TSQLLint.Tests.UnitTests.Config
             // assert
             Assert.AreEqual(RuleViolationSeverity.Off, configReader.GetRuleSeverity("select-star"));
             Assert.AreEqual(RuleViolationSeverity.Off, configReader.GetRuleSeverity("statement-semicolon-termination"));
+            Assert.IsFalse(configReader.IsConfigLoaded);
         }
 
         [Test]
@@ -65,6 +69,7 @@ namespace TSQLLint.Tests.UnitTests.Config
             // assert
             Assert.AreEqual(RuleViolationSeverity.Off, configReader.GetRuleSeverity("select-star"));
             Assert.AreEqual(RuleViolationSeverity.Off, configReader.GetRuleSeverity("statement-semicolon-termination"));
+            Assert.IsFalse(configReader.IsConfigLoaded);
         }
 
         [Test]
@@ -94,6 +99,7 @@ namespace TSQLLint.Tests.UnitTests.Config
             // assert
             Assert.AreEqual(RuleViolationSeverity.Error, configReader.GetRuleSeverity("select-star"));
             Assert.AreEqual(RuleViolationSeverity.Warning, configReader.GetRuleSeverity("statement-semicolon-termination"));
+            Assert.IsTrue(configReader.IsConfigLoaded);
         }
 
         [Test]
@@ -116,6 +122,7 @@ namespace TSQLLint.Tests.UnitTests.Config
                 // act
                 var configReader = new ConfigReader(reporter, fileSystem);
                 Assert.IsNotNull(configReader);
+                Assert.IsFalse(configReader.IsConfigLoaded);
             });
         }
 
@@ -144,6 +151,7 @@ namespace TSQLLint.Tests.UnitTests.Config
 
             // assert
             Assert.AreEqual(RuleViolationSeverity.Off, configReader.GetRuleSeverity("foo"), "Rules that dont have a validator should be set to off");
+            Assert.IsFalse(configReader.IsConfigLoaded);
         }
 
         [Test]
@@ -170,6 +178,7 @@ namespace TSQLLint.Tests.UnitTests.Config
 
             // assert
             Assert.AreEqual(RuleViolationSeverity.Off, configReader.GetRuleSeverity("select-star"), "Rules that dont have a valid severity should be set to off");
+            Assert.IsTrue(configReader.IsConfigLoaded);
         }
 
         [Test]
@@ -192,6 +201,7 @@ namespace TSQLLint.Tests.UnitTests.Config
 
             // assert
             reporter.Received().Report("Config file is not valid Json.");
+            Assert.IsFalse(configReader.IsConfigLoaded);
         }
 
         [Test]
@@ -224,16 +234,22 @@ namespace TSQLLint.Tests.UnitTests.Config
             var configReader = new ConfigReader(reporter, fileSystem);
             configReader.LoadConfigFromFile(configFilePath);
             var plugins = configReader.GetPlugins();
+            configReader.ListPlugins();
 
             // assert
             Assert.AreEqual(RuleViolationSeverity.Error, configReader.GetRuleSeverity("select-star"));
             Assert.AreEqual(RuleViolationSeverity.Warning, configReader.GetRuleSeverity("statement-semicolon-termination"));
+            Assert.IsTrue(configReader.IsConfigLoaded);
 
             Assert.AreEqual(true, plugins.ContainsKey("my-first-plugin"));
             Assert.AreEqual(true, plugins.ContainsKey("my-second-plugin"));
 
             Assert.AreEqual("c:/users/someone/my-plugins/my-first-plugin.dll", plugins["my-first-plugin"]);
             Assert.AreEqual("c:/users/someone/my-plugins/my-second-plugin.dll", plugins["my-second-plugin"]);
+
+            reporter.Received().Report("Found the following plugins:");
+            reporter.Received().Report("Plugin Name 'my-first-plugin' loaded from path 'c:/users/someone/my-plugins/my-first-plugin.dll'");
+            reporter.Received().Report("Plugin Name 'my-second-plugin' loaded from path 'c:/users/someone/my-plugins/my-second-plugin.dll'");
         }
     }
 }

--- a/TSQLLint.Tests/UnitTests/PluginHandler/PluginHandlerTests.cs
+++ b/TSQLLint.Tests/UnitTests/PluginHandler/PluginHandlerTests.cs
@@ -13,7 +13,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
     public class PluginHandlerTests
     {
         [Test]
-        public void LoadPlugins_ShouldLoadIPluginsFromPathAndFile()
+        public void LoadPlugins_ShouldLoadPluginsFromPathAndFile()
         {
             // arrange
             const string filePath1 = @"c:\pluginDirectory\plugin_one.dll";
@@ -139,7 +139,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             assemblyWrapper.GetExportedTypes(assembly).Returns(
                 new[]
                 {
-                    typeof(TestPlugin_ThrowsException)
+                    typeof(TestPluginThrowsException)
                 });
 
             var pluginPaths = new Dictionary<string, string>    
@@ -167,7 +167,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             reporter.Received().Report(Arg.Any<string>());
         }
 
-        public class TestPlugin_ThrowsException : IPlugin
+        public class TestPluginThrowsException : IPlugin
         {
             public void PerformAction(IPluginContext context, IReporter reporter)
             {


### PR DESCRIPTION
Should now be able to use the -l option to list the plug-ins. As with print-config this will not do the linting.

Example message:
Found the following plugins:
Plugin Name 'mc-plugin' loaded from path 'D:/TFS/Repos/TSQLLint-MC-Plugin/bin/Debug/TSQLLint MC Plugin.dll'