### PR TITLE
Does not load a plugin in twice

### DIFF
--- a/TSQLLint.Console/Application.cs
+++ b/TSQLLint.Console/Application.cs
@@ -18,6 +18,7 @@ namespace TSQLLint.Console
         private readonly ICommandLineOptionHandler _commandLineOptionHandler;
         private readonly CommandLineOptions.CommandLineOptions _commandLineOptions;
         private readonly IConfigReader _configReader;
+        private readonly IPluginHandler _pluginHandler;
         private readonly ISqlFileProcessor _fileProcessor;
         private readonly IReporter _reporter;
         private readonly IConsoleTimer _timer;
@@ -34,13 +35,14 @@ namespace TSQLLint.Console
             var fragmentBuilder = new FragmentBuilder();
             var ruleVisitorBuilder = new RuleVisitorBuilder(_configReader, _reporter);
             IRuleVisitor ruleVisitor = new SqlRuleVisitor(ruleVisitorBuilder, fragmentBuilder, reporter);
-            IPluginHandler pluginHandler = new PluginHandler(reporter, _configReader.GetPlugins());
-            _fileProcessor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, new FileSystem());
+            _pluginHandler = new PluginHandler(reporter);
+            _fileProcessor = new SqlFileProcessor(ruleVisitor, _pluginHandler, reporter, new FileSystem());
         }
 
         public void Run()
         {
             _configReader.LoadConfig(_commandLineOptions.ConfigFile);
+            _pluginHandler.ProcessPaths(_configReader.GetPlugins());
             _commandLineOptionHandler.HandleCommandLineOptions(_commandLineOptions);
             _fileProcessor.ProcessList(_commandLineOptions.LintPath);
 

--- a/TSQLLint.Lib/Plugins/Interfaces/IPluginHandler.cs
+++ b/TSQLLint.Lib/Plugins/Interfaces/IPluginHandler.cs
@@ -7,6 +7,8 @@ namespace TSQLLint.Lib.Plugins.Interfaces
     {
         IList<IPlugin> Plugins { get; }
 
+        void ProcessPaths(Dictionary<string, string> pluginPaths);
+
         void ProcessPath(string path);
 
         void LoadPluginDirectory(string path);

--- a/TSQLLint.Lib/Plugins/PluginHandler.cs
+++ b/TSQLLint.Lib/Plugins/PluginHandler.cs
@@ -17,23 +17,26 @@ namespace TSQLLint.Lib.Plugins
         private readonly IFileSystem _fileSystem;
         private Dictionary<Type, IPlugin> _plugins;
 
-        public PluginHandler(IReporter reporter, Dictionary<string, string> pluginPaths) : this(reporter, pluginPaths, new FileSystem(), new AssemblyWrapper()) { }
+        public PluginHandler(IReporter reporter) : this(reporter, new FileSystem(), new AssemblyWrapper()) { }
 
-        public PluginHandler(IReporter reporter, Dictionary<string, string> pluginPaths, IFileSystem fileSystem, IAssemblyWrapper assemblyWrapper)
+        public PluginHandler(IReporter reporter, IFileSystem fileSystem, IAssemblyWrapper assemblyWrapper)
         {
             _reporter = reporter;
             _fileSystem = fileSystem;
             _assemblyWrapper = assemblyWrapper;
-
-            foreach (var pluginPath in pluginPaths)
-            {
-                ProcessPath(pluginPath.Value);
-            }
         }
 
         public IList<IPlugin> Plugins => _plugins.Values.ToList();
 
         private Dictionary<Type, IPlugin> List => _plugins ?? (_plugins = new Dictionary<Type, IPlugin>());
+
+        public void ProcessPaths(Dictionary<string, string> pluginPaths)
+        {
+            foreach (var pluginPath in pluginPaths)
+            {
+                ProcessPath(pluginPath.Value);
+            }
+        }
 
         public void ProcessPath(string path)
         {

--- a/TSQLLint.Tests/UnitTests/PluginHandler/PluginHandlerTests.cs
+++ b/TSQLLint.Tests/UnitTests/PluginHandler/PluginHandlerTests.cs
@@ -22,6 +22,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             const string filePath3 = @"c:\pluginDirectory\plugin_three.dll";
             const string filePath4 = @"c:\pluginDirectory\foo.txt";
             const string filePath5 = @"c:\pluginDirectory\subDirectory\bar.txt";
+            const string filePath6 = @"c:\pluginDirectory\subDirectory\plugin_four.dll";
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -39,19 +40,19 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                 },
                 {
                     filePath5, new MockFileData("bar")
-                }
+                },
+                {
+                    filePath6, new MockFileData(string.Empty)
+                },
             });
 
-            var assembly = Assembly.GetExecutingAssembly();
-
-            var assemblyWrapper = Substitute.For<IAssemblyWrapper>();
-            assemblyWrapper.LoadFile(Arg.Any<string>()).Returns(assembly);
-            assemblyWrapper.GetExportedTypes(assembly).Returns(
-                new[]
-                {
-                    typeof(TestPlugin),
-                    typeof(string)
-                });
+            var assemblyWrapper = new TestAssemblyWrapper(new Dictionary<string, int>
+            {
+                { @"c:\pluginDirectory\plugin_one.dll", 0 },
+                { @"c:\pluginDirectory\plugin_two.dll", 1 },
+                { @"c:\pluginDirectory\plugin_three.dll", 2 },
+                { @"c:\pluginDirectory\subDirectory\plugin_four.dll", 3 }
+            });
 
             var reporter = Substitute.For<IReporter>();
 
@@ -61,7 +62,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                     "my-first-plugin", @"c:\pluginDirectory\"
                 },
                 {
-                    "my-second-plugin", @"c:\pluginDirectory\plugin_one.dll"
+                    "my-second-plugin", filePath6
                 }
             };
 
@@ -94,17 +95,8 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                 },
                 currentDirectory.FullName);
 
-            var assembly = Assembly.GetExecutingAssembly();
-
-            var assemblyWrapper = Substitute.For<IAssemblyWrapper>();
-            assemblyWrapper.LoadFile(Arg.Any<string>()).Returns(assembly);
-            assemblyWrapper.GetExportedTypes(assembly).Returns(
-                new[]
-                {
-                    typeof(TestPlugin),
-                    typeof(string)
-                });
-
+            var assemblyWrapper = new TestAssemblyWrapper();
+ 
             var reporter = Substitute.For<IReporter>();
 
             var pluginPaths = new Dictionary<string, string>
@@ -139,16 +131,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                 },
                 currentDirectory.FullName);
 
-            var assembly = Assembly.GetExecutingAssembly();
-
-            var assemblyWrapper = Substitute.For<IAssemblyWrapper>();
-            assemblyWrapper.LoadFile(Arg.Any<string>()).Returns(assembly);
-            assemblyWrapper.GetExportedTypes(assembly).Returns(
-                new[]
-                {
-                    typeof(TestPlugin),
-                    typeof(string)
-                });
+            var assemblyWrapper = new TestAssemblyWrapper();
 
             var reporter = Substitute.For<IReporter>();
 
@@ -167,6 +150,45 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
         }
 
         [Test]
+        public void LoadPlugins_ThrowErrors_When_Same_Type_Is_Loaded_More_Than_Once()
+        {
+            // arrange
+            const string filePath1 = @"c:\pluginDirectory\plugin_one.dll";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    filePath1, new MockFileData(string.Empty)
+                }
+            });
+
+            var assemblyWrapper = new TestAssemblyWrapper(defaultPlugin: typeof(TestPluginThrowsException));
+
+            var pluginPaths = new Dictionary<string, string>
+            {
+                {
+                    "my-plugin", filePath1
+                },
+                {
+                    "my-plugin-directories", @"c:\pluginDirectory"
+                },
+                {
+                    "my-plugin-invalid-path", @"c:\doesnt-exist"
+                }
+            };
+
+            var reporter = Substitute.For<IReporter>();
+
+            // act
+            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, pluginPaths, fileSystem, assemblyWrapper);
+
+            // assert
+            Assert.AreEqual(1, pluginHandler.Plugins.Count);
+            var type = typeof(TestPluginThrowsException);
+            reporter.Received().Report($"\nLoaded plugin '{type.FullName}'\n");
+            reporter.Received().Report($"\nAlready loaded plugin with type '{type.FullName}'\n");
+        }
+
+        [Test]
         public void ActivatePlugins_PluginRuleViolations_ShouldCallReporter()
         {
             // arrange
@@ -178,16 +200,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                 }
             });
 
-            var assembly = Assembly.GetExecutingAssembly();
-
-            var assemblyWrapper = Substitute.For<IAssemblyWrapper>();
-            assemblyWrapper.LoadFile(Arg.Any<string>()).Returns(assembly);
-            assemblyWrapper.GetExportedTypes(assembly).Returns(
-                new[]
-                {
-                    typeof(TestPlugin),
-                    typeof(string)
-                });
+            var assemblyWrapper = new TestAssemblyWrapper();
 
             var pluginPaths = new Dictionary<string, string>
             {
@@ -228,14 +241,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                 }
             });
 
-            var assemblyWrapper = Substitute.For<IAssemblyWrapper>();
-            var assembly = Assembly.GetExecutingAssembly();
-            assemblyWrapper.LoadFile(Arg.Any<string>()).Returns(assembly);
-            assemblyWrapper.GetExportedTypes(assembly).Returns(
-                new[]
-                {
-                    typeof(TestPluginThrowsException)
-                });
+            var assemblyWrapper = new TestAssemblyWrapper(defaultPlugin: typeof(TestPluginThrowsException));
 
             var pluginPaths = new Dictionary<string, string>    
             {
@@ -257,9 +263,21 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             var pluginHandler = new Lib.Plugins.PluginHandler(reporter, pluginPaths, fileSystem, assemblyWrapper);
 
             // assert
-            Assert.AreEqual(2, pluginHandler.Plugins.Count);
+            Assert.AreEqual(1, pluginHandler.Plugins.Count);
             Assert.Throws<NotImplementedException>(() => pluginHandler.ActivatePlugins(context));
             reporter.Received().Report(Arg.Any<string>());
+        }
+
+        public class TestPlugin2 : TestPlugin
+        {
+        }
+
+        public class TestPlugin3 : TestPlugin
+        {
+        }
+
+        public class TestPlugin4 : TestPlugin
+        {
         }
 
         public class TestPluginThrowsException : IPlugin
@@ -267,6 +285,47 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             public void PerformAction(IPluginContext context, IReporter reporter)
             {
                 throw new NotImplementedException();
+            }
+        }
+
+        public class TestAssemblyWrapper : IAssemblyWrapper
+        {
+            private readonly Assembly _assembly;
+            private readonly Dictionary<string, int> _pathsToPluginNumber;
+            private string _assemblyLoaded;
+            private Type _defaultPlugin;
+
+            public TestAssemblyWrapper(Dictionary<string, int> pathsToPluginNumber = null, Type defaultPlugin = null)
+            {
+                _assembly = Assembly.GetExecutingAssembly();
+                _pathsToPluginNumber = pathsToPluginNumber;
+                _defaultPlugin = defaultPlugin ?? typeof(TestPlugin);
+            }
+
+            public Assembly LoadFile(string path)
+            {
+                _assemblyLoaded = path;
+                return _assembly;
+            }
+
+            public Type[] GetExportedTypes(Assembly assembly)
+            {
+                if (_pathsToPluginNumber == null || !_pathsToPluginNumber.ContainsKey(_assemblyLoaded))
+                {
+                    return new[] { _defaultPlugin };
+                }
+
+                switch (_pathsToPluginNumber[_assemblyLoaded])
+                {
+                    case 0:
+                        return new[] { _defaultPlugin };
+                    case 1:
+                        return new[] { typeof(TestPlugin2) };
+                    case 2:
+                        return new[] { typeof(TestPlugin3) };
+                    default:
+                        return new[] { typeof(TestPlugin4) };
+                }
             }
         }
     }

--- a/TSQLLint.Tests/UnitTests/PluginHandler/PluginHandlerTests.cs
+++ b/TSQLLint.Tests/UnitTests/PluginHandler/PluginHandlerTests.cs
@@ -67,7 +67,8 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             };
 
             // act
-            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, pluginPaths, fileSystem, assemblyWrapper);
+            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, fileSystem, assemblyWrapper);
+            pluginHandler.ProcessPaths(pluginPaths);
 
             // assert
             Assert.AreEqual(4, pluginHandler.Plugins.Count);
@@ -107,7 +108,8 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             };
 
             // act
-            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, pluginPaths, fileSystem, assemblyWrapper);
+            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, fileSystem, assemblyWrapper);
+            pluginHandler.ProcessPaths(pluginPaths);
 
             // assert
             Assert.AreEqual(1, pluginHandler.Plugins.Count);
@@ -143,7 +145,8 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             };
 
             // act
-            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, pluginPaths, fileSystem, assemblyWrapper);
+            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, fileSystem, assemblyWrapper);
+            pluginHandler.ProcessPaths(pluginPaths);
 
             // assert
             Assert.AreEqual(1, pluginHandler.Plugins.Count);
@@ -179,7 +182,8 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             var reporter = Substitute.For<IReporter>();
 
             // act
-            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, pluginPaths, fileSystem, assemblyWrapper);
+            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, fileSystem, assemblyWrapper);
+            pluginHandler.ProcessPaths(pluginPaths);
 
             // assert
             Assert.AreEqual(1, pluginHandler.Plugins.Count);
@@ -214,7 +218,8 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             var context = new PluginContext(@"c:\scripts\foo.sql", textReader);
 
             // act
-            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, pluginPaths, fileSystem, assemblyWrapper);
+            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, fileSystem, assemblyWrapper);
+            pluginHandler.ProcessPaths(pluginPaths);
 
             // assert
             Assert.AreEqual(1, pluginHandler.Plugins.Count);
@@ -260,7 +265,8 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             var context = Substitute.For<IPluginContext>();
 
             // act
-            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, pluginPaths, fileSystem, assemblyWrapper);
+            var pluginHandler = new Lib.Plugins.PluginHandler(reporter, fileSystem, assemblyWrapper);
+            pluginHandler.ProcessPaths(pluginPaths);
 
             // assert
             Assert.AreEqual(1, pluginHandler.Plugins.Count);


### PR DESCRIPTION
Will log (not error) the fact that a Type was seen twice instead of loading it twice. Also fixed loading of plugins after config is parsed.