### PR TITLE
pr process.arch bug in setup script. 

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -13,7 +13,7 @@ if (os.type() === 'Darwin') {
 } else if (os.type() === 'Linux') {
   runTime = 'linux-x64'
 } else if (os.type() === 'Windows_NT') {
-  if (process.arch === 'x32') {
+  if (process.arch === 'ia32') {
     runTime = 'win-x86'
   } else if (process.arch === 'x64') {
     runTime = 'win-x64'


### PR DESCRIPTION
I was getting a malformed download url due to the process.arch value parsing in the script:

D:\Code\ChangeRequests\AppDB>npm install -g tsqllint
C:\Users\dgasperut\AppData\Roaming\npm\tsqllint -> C:\Users\dgasperut\AppData\Roaming\npm\node_modules\tsqllint\tsqllint.js

> tsqllint@1.8.6 install C:\Users\dgasperut\AppData\Roaming\npm\node_modules\tsqllint
> node ./scripts/install.js

Error: There was a problem downloading https://github.com/tsqllint/tsqllint/releases/download/v1.8.6/.tgz
    at Writable.https.get.on (C:\Users\dgasperut\AppData\Roaming\npm\node_modules\tsqllint\scripts\install.js:37:27)
    at emitOne (events.js:101:20)
    at Writable.emit (events.js:188:7)
    at Writable.RedirectableRequest._processResponse 