### PR TITLE
Allow files with syntax errors to be linted

### DIFF
--- a/TSQLLint.Console/TSQLLint.Console.csproj
+++ b/TSQLLint.Console/TSQLLint.Console.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="TSQLLint.Common" Version="1.0.15" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/TSQLLint.Lib/Parser/SqlRuleVisitor.cs
+++ b/TSQLLint.Lib/Parser/SqlRuleVisitor.cs
@@ -34,7 +34,7 @@ namespace TSQLLint.Lib.Parser
             TextReader sqlTextReader = new StreamReader(sqlFileStream);
             var sqlFragment = fragmentBuilder.GetFragment(sqlTextReader, out var errors);
 
-            if (errors.Count > 0)
+            if (sqlFragment == null)
             {
                 reporter.ReportViolation(new RuleViolation(sqlPath, null, "TSQL not syntactically correct", 0, 0, RuleViolationSeverity.Error));
                 Environment.ExitCode = 1;

--- a/TSQLLint.Lib/Parser/SqlRuleVisitor.cs
+++ b/TSQLLint.Lib/Parser/SqlRuleVisitor.cs
@@ -34,13 +34,6 @@ namespace TSQLLint.Lib.Parser
             TextReader sqlTextReader = new StreamReader(sqlFileStream);
             var sqlFragment = fragmentBuilder.GetFragment(sqlTextReader, out var errors);
 
-            if (sqlFragment == null)
-            {
-                reporter.ReportViolation(new RuleViolation(sqlPath, null, "TSQL not syntactically correct", 0, 0, RuleViolationSeverity.Error));
-                Environment.ExitCode = 1;
-                return;
-            }
-
             sqlFileStream.Seek(0, SeekOrigin.Begin);
             var ignoredRules = ruleExceptionFinder.GetIgnoredRuleList(sqlFileStream).ToList();
 

--- a/TSQLLint.Lib/TSQLLint.Lib.csproj
+++ b/TSQLLint.Lib/TSQLLint.Lib.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="System.IO.Abstractions" Version="2.1.0.176" />
     <PackageReference Include="TSQLLint.Common" Version="1.0.15" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/TSQLLint.Tests/FunctionalTests/ConsoleAppTests.cs
+++ b/TSQLLint.Tests/FunctionalTests/ConsoleAppTests.cs
@@ -49,7 +49,7 @@ namespace TSQLLint.Tests.FunctionalTests
         [TestCase(@"TestFiles/no-errors.sql", 0)]
         [TestCase(@"TestFiles/with-warnings.sql", 0)]
         [TestCase(@"TestFiles/with-errors.sql", 1)]
-        [TestCase(@"TestFiles/invalid-syntax.sql", 1)]
+        [TestCase(@"TestFiles/invalid-syntax.sql", 0)]
         public void LintingExitCodeTest(string testFile, int expectedExitCode)
         {
             var fileLinted = false;

--- a/TSQLLint.Tests/IntegrationTests/Configuration/CommandLineOptionTests.cs
+++ b/TSQLLint.Tests/IntegrationTests/Configuration/CommandLineOptionTests.cs
@@ -84,7 +84,7 @@ namespace TSQLLint.Tests.IntegrationTests.Configuration
                 yield return new TestCaseData(new List<string> { TestFileOne, TestFileTwo }, null, MultiFileRuleViolations, 2).SetName("File Args Valid Lint Two Files");
                 yield return new TestCaseData(new List<string> { TestFileTwo, TestFileOne }, null, MultiFileRuleViolations, 2).SetName("File Args Valid Lint Two Files, Changed Order");
                 yield return new TestCaseData(new List<string> { TestFileDirectory }, null, AllRuleViolations, 3).SetName("File Args Valid Lint Directory");
-                yield return new TestCaseData(new List<string> { TestFileInvalidSyntax }, null, TestFileInvalidSyntaxRuleViolations, 1).SetName("File Args Invalid due to Invalid Syntax");
+                yield return new TestCaseData(new List<string> { TestFileInvalidSyntax }, null, TestFileInvalidSyntaxRuleViolations, 1).SetName("File Args not invalid due to Invalid Syntax");
             }
         }
 

--- a/TSQLLint.Tests/IntegrationTests/IntegrationBaseTest.cs
+++ b/TSQLLint.Tests/IntegrationTests/IntegrationBaseTest.cs
@@ -40,7 +40,11 @@ namespace TSQLLint.Tests.IntegrationTests
 
         protected static readonly IEnumerable<RuleViolation> TestFileInvalidSyntaxRuleViolations = new List<RuleViolation>
         {
-            new RuleViolation(null, null, "TSQL not syntactically correct", 0, 0, RuleViolationSeverity.Error)
+            new RuleViolation("keyword-capitalization", 1, 1),
+            new RuleViolation("set-ansi", 1, 1),
+            new RuleViolation("set-nocount", 1, 1),
+            new RuleViolation("set-quoted-identifier", 1, 1),
+            new RuleViolation("set-transaction-isolation-level", 1, 1),
         };
 
         protected static readonly IEnumerable<RuleViolation> TestFileTwoRuleViolations = new List<RuleViolation>


### PR DESCRIPTION
This is so that the [extension can handle files with syntax errors](https://github.com/tsqllint/tsqllint-vscode-extension/issues/1).