### PR TITLE
Issue 131 END CATCH;

### DIFF
--- a/TSQLLint.Lib/Rules/SemicolonTerminationRule.cs
+++ b/TSQLLint.Lib/Rules/SemicolonTerminationRule.cs
@@ -20,7 +20,6 @@ namespace TSQLLint.Lib.Rules
             typeof(GoToStatement),
             typeof(IndexDefinition),
             typeof(LabelStatement),
-            typeof(TryCatchStatement),
             typeof(WhileStatement),
             typeof(IfStatement)
         };

--- a/TSQLLint.Tests/UnitTests/Rules/semicolon-termination/SemicolonTerminationRuleTests.cs
+++ b/TSQLLint.Tests/UnitTests/Rules/semicolon-termination/SemicolonTerminationRuleTests.cs
@@ -44,6 +44,7 @@ namespace TSQLLint.Tests.UnitTests.Rules
               {
                   new RuleViolation("semicolon-termination", 1, 20),
                   new RuleViolation("semicolon-termination", 4, 13),
+                  new RuleViolation("semicolon-termination", 8, 10),
                   new RuleViolation("semicolon-termination", 12, 47),
                   new RuleViolation("semicolon-termination", 14, 29),
                   new RuleViolation("semicolon-termination", 19, 47),

--- a/TSQLLint.Tests/UnitTests/Rules/semicolon-termination/test-files/semicolon-termination-multiple-errors.sql
+++ b/TSQLLint.Tests/UnitTests/Rules/semicolon-termination/test-files/semicolon-termination-multiple-errors.sql
@@ -5,7 +5,7 @@ BEGIN TRY;
 END TRY
 BEGIN CATCH;  
     SELECT 2;
-END CATCH;
+END CATCH --violation
 
 CREATE TABLE t1 (
   ColumnOne int, 

--- a/TSQLLint.Tests/UnitTests/Rules/semicolon-termination/test-files/semicolon-termination-try-catch-while.sql
+++ b/TSQLLint.Tests/UnitTests/Rules/semicolon-termination/test-files/semicolon-termination-try-catch-while.sql
@@ -3,7 +3,7 @@
 END TRY
 BEGIN CATCH
     SELECT 2;
-END CATCH
+END CATCH;
 
 DECLARE @KeepGoing INT = 1;
 WHILE (@KeepGoing = 1)


### PR DESCRIPTION
Throw semicolon error when missing; from end catch. This seems to be MSDN preference. 

https://docs.microsoft.com/en-us/sql/t-sql/language-elements/try-catch-transact-sql

If there's a reason not to do this, I can make it an optional by putting it in it's own rule set. 