### PR TITLE
Multi threading support

### DIFF
--- a/source/TSQLLint.Console/Application.cs
+++ b/source/TSQLLint.Console/Application.cs
@@ -1,8 +1,5 @@
 using System;
 using System.IO.Abstractions;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.SqlServer.TransactSql.ScriptDom;
 using TSQLLint.Common;
 using TSQLLint.Core.DTO;
 using TSQLLint.Core.Interfaces;
@@ -27,13 +24,13 @@ namespace TSQLLint.Console
         private IPluginHandler pluginHandler;
         private ISqlFileProcessor fileProcessor;
 
-        public Application(string[] args, IReporter reporter)
+        public Application(ICommandLineOptions options, IReporter reporter)
         {
             timer = new ConsoleTimer();
             timer.Start();
 
             this.reporter = reporter;
-            commandLineOptions = new CommandLineOptions(args);
+            this.commandLineOptions = options;
             configReader = new ConfigReader(reporter);
             commandLineOptionHandler = new CommandLineOptionHandler(
                 new ConfigFileGenerator(),
@@ -50,7 +47,7 @@ namespace TSQLLint.Console
             var ruleVisitorBuilder = new RuleVisitorBuilder(configReader, this.reporter);
             var ruleVisitor = new SqlRuleVisitor(ruleVisitorBuilder, fragmentBuilder, reporter);
             pluginHandler = new PluginHandler(reporter);
-            fileProcessor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, new FileSystem());
+            fileProcessor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, new FileSystem(), commandLineOptions.Threads ?? 1);
 
             pluginHandler.ProcessPaths(configReader.GetPlugins());
             var response = commandLineOptionHandler.Handle(new CommandLineRequestMessage(commandLineOptions));

--- a/source/TSQLLint.Console/Program.cs
+++ b/source/TSQLLint.Console/Program.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using TSQLLint.Core.Interfaces;
+using TSQLLint.Infrastructure.CommandLineOptions;
 using TSQLLint.Infrastructure.Reporters;
 
 namespace TSQLLint.Console
@@ -20,8 +21,10 @@ namespace TSQLLint.Console
 
             ICommandLineOptions options = new CommandLineOptions(args);
 
-                reporter = new ConsoleReporter();
+            IAwaitableReporter reporter = new ConsoleReporter();
+
             var application = new Application(options, reporter);
+
             try
             {
                 application.Run();

--- a/source/TSQLLint.Console/Program.cs
+++ b/source/TSQLLint.Console/Program.cs
@@ -17,16 +17,17 @@ namespace TSQLLint.Console
 
             var configuration = builder.Build();
             var debug = configuration.GetValue("debug", false);
-            var application = new Application(args, new ConsoleReporter());
 
+            ICommandLineOptions options = new CommandLineOptions(args);
+
+                reporter = new ConsoleReporter();
+            var application = new Application(options, reporter);
             try
             {
                 application.Run();
 
-                Task.Run(() =>
-                {
-                    while (NonBlockingConsole.messageQueue.Count > 0) { }
-                }).Wait();
+                // wait for the reporter to finish
+                reporter.ReportingTask.Wait();
             }
             catch (Exception exception)
             {

--- a/source/TSQLLint.Core/Interfaces/ICommandLineOptions.cs
+++ b/source/TSQLLint.Core/Interfaces/ICommandLineOptions.cs
@@ -22,6 +22,7 @@ namespace TSQLLint.Core.Interfaces
 
         bool Version { get; set; }
 
+        int? Threads { get; set; }
         string GetUsage();
     }
 }

--- a/source/TSQLLint.Infrastructure/CommandLineOptions/CommandLineOptions.cs
+++ b/source/TSQLLint.Infrastructure/CommandLineOptions/CommandLineOptions.cs
@@ -67,6 +67,12 @@ namespace TSQLLint.Infrastructure.CommandLineOptions
             HelpText = "Display this help dialog")]
         public bool Help { get; set; }
 
+        [Option(
+            't',
+            longName: "threads",
+            Required = false,
+            HelpText = "Specify how many threads to process concurrently, defaults to 1")]
+        public int? Threads { get; set; }
         [HelpVerbOption]
         public string GetUsage()
         {

--- a/source/TSQLLint.Infrastructure/Reporters/ConsoleReporter.cs
+++ b/source/TSQLLint.Infrastructure/Reporters/ConsoleReporter.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using TSQLLint.Common;
 
 namespace TSQLLint.Infrastructure.Reporters
 {
-    public class ConsoleReporter : IReporter
+    public class ConsoleReporter : IAwaitableReporter
     {
         private int warningCount;
         private int errorCount;
@@ -31,10 +32,10 @@ namespace TSQLLint.Infrastructure.Reporters
             switch (violation.Severity)
             {
                 case RuleViolationSeverity.Warning:
-                    warningCount++;
+                    Interlocked.Increment(ref warningCount);
                     break;
                 case RuleViolationSeverity.Error:
-                    errorCount++;
+                    Interlocked.Increment(ref errorCount);
                     break;
                 default:
                     return;
@@ -53,5 +54,7 @@ namespace TSQLLint.Infrastructure.Reporters
         {
             Report($"{fileName}({line},{column}): {severity} {ruleName} : {violationText}.");
         }
+
+        public Task ReportingTask => Task.Run(() => { while (NonBlockingConsole.messageQueue.Count > 0) { } });
     }
 }

--- a/source/TSQLLint.Infrastructure/Reporters/IAwaitableReporter.cs
+++ b/source/TSQLLint.Infrastructure/Reporters/IAwaitableReporter.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using TSQLLint.Common;
+
+namespace TSQLLint.Infrastructure.Reporters
+{
+    public interface  IAwaitableReporter : IReporter
+    {
+        Task ReportingTask { get; }
+    }
+}

--- a/source/TSQLLint.Tests/Helpers/TestHelper.cs
+++ b/source/TSQLLint.Tests/Helpers/TestHelper.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using NUnit.Framework;
 using TSQLLint.Common;
 using TSQLLint.Console;
+using TSQLLint.Infrastructure.CommandLineOptions;
 using TSQLLint.Infrastructure.Rules.RuleViolations;
 using TSQLLint.Tests.Helpers.ObjectComparers;
 
@@ -18,7 +19,7 @@ namespace TSQLLint.Tests.Helpers
             // arrange
             expectedRuleViolations = expectedRuleViolations.OrderBy(o => o.Line).ToList();
 
-            var appArgs = argumentsUnderTest.ToArray();
+            var appArgs = new CommandLineOptions(argumentsUnderTest.ToArray());
             var mockReporter = Substitute.For<IReporter>();
 
             var reportedViolations = new List<IRuleViolation>();

--- a/source/TSQLLint.Tests/UnitTests/Parser/SqlFileProcessorTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/Parser/SqlFileProcessorTests.cs
@@ -36,7 +36,9 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var fileSystem = Substitute.For<IFileSystem>();
             var fileBase = Substitute.For<FileBase>();
             var pluginHandler = Substitute.For<IPluginHandler>();
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var maxThreads = 1;
+
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             fileBase.Exists(filePath).Returns(true);
             fileBase.OpenRead(filePath).Returns(ParsingUtility.GenerateStreamFromString("Some Sql To Parse"));
@@ -48,7 +50,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             // assert
             fileBase.Received().Exists(filePath);
             fileBase.Received().OpenRead(filePath);
-            ruleVisitor.Received().VisitRules(filePath, Arg.Any<IEnumerable<IExtendedRuleException>>(),  Arg.Any<Stream>());
+            ruleVisitor.Received().VisitRules(filePath, Arg.Any<IEnumerable<IExtendedRuleException>>(), Arg.Any<Stream>());
             Assert.AreEqual(1, processor.FileCount);
         }
 
@@ -64,6 +66,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var pluginHandler = Substitute.For<IPluginHandler>();
             var reporter = Substitute.For<IReporter>();
+            var maxThreads = 1;
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -81,7 +84,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessPath("\" " + @"c:\DBScripts" + " \"");
@@ -106,6 +109,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var maxThreads = 1;
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -123,7 +127,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessPath(@"c:\DBScripts");
@@ -147,6 +151,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var fileSystem = Substitute.For<IFileSystem>();
             var fileBase = Substitute.For<FileBase>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var maxThreads = 1;
 
             fileBase.Exists(filePath).Returns(false);
             fileSystem.File.Returns(fileBase);
@@ -154,7 +159,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             directoryBase.Exists(filePath).Returns(false);
             fileSystem.Directory.Returns(directoryBase);
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessPath(filePath);
@@ -179,6 +184,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var maxThreads = 1;
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -196,7 +202,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessPath(@"c:\DBScripts\file?.sql");
@@ -222,6 +228,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var maxThreads = 1;
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -242,7 +249,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessPath(@"c:\DBScripts\file*.*");
@@ -265,6 +272,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var maxThreads = 1;
 
             var fileSystem = new MockFileSystem(
                 new Dictionary<string, MockFileData>
@@ -275,7 +283,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 },
                 @"c:\dbscripts");
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessPath(@"c:\doesntExist\file*.*");
@@ -299,6 +307,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var maxThreads = 1;
 
             var fileSystem = new MockFileSystem(
                 new Dictionary<string, MockFileData>
@@ -321,7 +330,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 },
                 @"c:\dbscripts");
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessPath(@"file*.*");
@@ -345,6 +354,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var maxThreads = 1;
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -353,7 +363,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessPath(@"c:\DBScripts\invalid*.*");
@@ -372,7 +382,9 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var reporter = Substitute.For<IReporter>();
             var fileSystem = Substitute.For<IFileSystem>();
             var pluginHandler = Substitute.For<IPluginHandler>();
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var maxThreads = 1;
+
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessList(new List<string>());
@@ -394,6 +406,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var maxThreads = 1;
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -411,7 +424,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessList(new List<string> { "\" c:\\dbscripts\\db2\\sproc , c:\\dbscripts\\db2\\file3.sql \"", @"c:\dbscripts\db1\" });             // tests quotes, extra spaces, commas, multiple items in the list
@@ -435,6 +448,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var maxThreads = 1;
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -446,7 +460,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, maxThreads);
 
             // act
             processor.ProcessList(new List<string> { invalidFilePath, @"c:\dbscripts\db1\" });


### PR DESCRIPTION
Add support for processing with multiple threads and command line option to override. Still defaults to 1 when not specified

I'm using this to lint a directory with ish 3000 scripts or more, single threaded this was taking around 2 minutes. Support for multi threading enabled me to get it down to around 30s 

Thoughts?