### PR TITLE
Implement placeholder replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ Setting the compatability level using inline comments configures the Compatabili
 SELECT * FROM FOO;
 ```
 
+## SQL Placeholders
+
+Many tools in the SQL ecosystem support placeholders to templatize SQL files as shown in the example below:
+
+```sql
+SELECT * FROM FOO WHERE BAR = '$(MyPlaceholderValue)';
+```
+
+Before applying any linting rules, TSQLLint will replace any placeholder in a SQL file with values provided via environment variables.
+
 ## Plugins
 
 You can extend the base functionality of TSQLLint by creating a custom plugin. TSQLLint plugins are Dotnet assemblies that implement the IPlugin interface from [TSQLLint.Common](https://www.nuget.org/packages/TSQLLint.Common/).  Ensure the plugin is targeting `netcoreapp2.0`.

--- a/source/TSQLLint.Infrastructure/Interfaces/ISqlStreamReaderBuilder.cs
+++ b/source/TSQLLint.Infrastructure/Interfaces/ISqlStreamReaderBuilder.cs
@@ -1,0 +1,9 @@
+using System.IO;
+
+namespace TSQLLint.Infrastructure.Interfaces
+{
+    public interface ISqlStreamReaderBuilder
+    {
+        StreamReader CreateReader(Stream sqlFileStream);
+    }
+}

--- a/source/TSQLLint.Infrastructure/Parser/SqlStreamReaderBuilder.cs
+++ b/source/TSQLLint.Infrastructure/Parser/SqlStreamReaderBuilder.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using TSQLLint.Core.Interfaces;
+using TSQLLint.Infrastructure.Configuration;
+using TSQLLint.Infrastructure.Interfaces;
+
+namespace TSQLLint.Infrastructure.Parser
+{
+    public class SqlStreamReaderBuilder : ISqlStreamReaderBuilder
+    {
+        private static readonly Regex PlaceholderRegex = new Regex(@"\$\((?<placeholder>[^)]+)\)", RegexOptions.Compiled);
+
+        private readonly IEnvironmentWrapper environmentWrapper;
+
+        public SqlStreamReaderBuilder()
+            : this(new EnvironmentWrapper()) { }
+
+        public SqlStreamReaderBuilder(IEnvironmentWrapper environmentWrapper)
+        {
+            this.environmentWrapper = environmentWrapper;
+        }
+
+        public StreamReader CreateReader(Stream sqlFileStream)
+        {
+            var sqlText = new StreamReader(sqlFileStream);
+            sqlFileStream.Seek(0, SeekOrigin.Begin);
+            var sql = ReplaceSqlPlaceholders(sqlText.ReadToEnd());
+            return new StreamReader(new MemoryStream(sqlText.CurrentEncoding.GetBytes(sql)));
+        }
+
+        private string ReplaceSqlPlaceholders(string sql)
+        {
+            var matches = PlaceholderRegex.Matches(sql);
+
+            if (matches.Count == 0)
+            {
+                return sql;
+            }
+
+            var newSql = new StringBuilder();
+            var i = 0;
+
+            foreach (Match match in matches)
+            {
+                var placeholder = match.Groups["placeholder"].Value;
+                var replacement = environmentWrapper.GetEnvironmentVariable(placeholder) ?? match.Value;
+                newSql.Append(sql.Substring(i, match.Index - i));
+                newSql.Append(replacement);
+                i = match.Index + match.Length;
+            }
+
+            newSql.Append(sql.Substring(i));
+
+            return newSql.ToString();
+        }
+    }
+}

--- a/source/TSQLLint.Tests/UnitTests/Parser/SqlStreamReaderBuilderTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/Parser/SqlStreamReaderBuilderTests.cs
@@ -1,0 +1,81 @@
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using NUnit.Framework;
+using TSQLLint.Core.Interfaces;
+using TSQLLint.Infrastructure.Parser;
+
+namespace TSQLLint.Tests.UnitTests.Parser
+{
+    [TestFixture]
+    public class SqlStreamReaderBuilderTests
+    {
+        [Test]
+        public void CreateReader_WithoutPlaceholders_DoesNotChangeSql()
+        {
+            // arrange
+            var mockEnvironmentWrapper = Substitute.For<IEnvironmentWrapper>();
+            var inputSql = "select 1;";
+
+            // act
+            var outputSql = new SqlStreamReaderBuilder(mockEnvironmentWrapper)
+                .CreateReader(ParsingUtility.GenerateStreamFromString(inputSql))
+                .ReadToEnd();
+
+            // assert
+            Assert.AreEqual(inputSql, outputSql);
+        }
+
+        [Test]
+        public void CreateReader_WithPlaceholdersButNoEnvironmentVariables_DoesNotChangeSql()
+        {
+            // arrange
+            var mockEnvironmentWrapper = Substitute.For<IEnvironmentWrapper>();
+            mockEnvironmentWrapper.GetEnvironmentVariable("bar").ReturnsNull();
+            var inputSql = "select 1 where foo = $(bar);";
+
+            // act
+            var outputSql = new SqlStreamReaderBuilder(mockEnvironmentWrapper)
+                .CreateReader(ParsingUtility.GenerateStreamFromString(inputSql))
+                .ReadToEnd();
+
+            // assert
+            Assert.AreEqual(inputSql, outputSql);
+        }
+
+        [Test]
+        public void CreateReader_WithPlaceholdersAndAllEnvironmentVariables_ChangesSql()
+        {
+            // arrange
+            var mockEnvironmentWrapper = Substitute.For<IEnvironmentWrapper>();
+            mockEnvironmentWrapper.GetEnvironmentVariable("foo").Returns("1");
+            mockEnvironmentWrapper.GetEnvironmentVariable("bar").Returns("bar");
+            var inputSql = "select 1 where foo = $(foo) and bar = '$(bar)';";
+
+            // act
+            var outputSql = new SqlStreamReaderBuilder(mockEnvironmentWrapper)
+                .CreateReader(ParsingUtility.GenerateStreamFromString(inputSql))
+                .ReadToEnd();
+
+            // assert
+            Assert.AreEqual("select 1 where foo = 1 and bar = 'bar';", outputSql);
+        }
+
+        [Test]
+        public void CreateReader_WithPlaceholdersAndSomeEnvironmentVariables_ChangesSql()
+        {
+            // arrange
+            var mockEnvironmentWrapper = Substitute.For<IEnvironmentWrapper>();
+            mockEnvironmentWrapper.GetEnvironmentVariable("foo").Returns("foo");
+            mockEnvironmentWrapper.GetEnvironmentVariable("bar").ReturnsNull();
+            var inputSql = "select 1 where foo = '$(foo)' and bar = '$(bar)';";
+
+            // act
+            var outputSql = new SqlStreamReaderBuilder(mockEnvironmentWrapper)
+                .CreateReader(ParsingUtility.GenerateStreamFromString(inputSql))
+                .ReadToEnd();
+
+            // assert
+            Assert.AreEqual("select 1 where foo = 'foo' and bar = '$(bar)';", outputSql);
+        }
+    }
+}


### PR DESCRIPTION
Many tools in the SQL ecosystem (e.g. [Invoke-Sqlcmd](https://docs.microsoft.com/en-us/powershell/module/sqlserver/invoke-sqlcmd)) support placeholders to inject variables into SQL scripts as shown in the example below:

```sql
SELECT * FROM foo WHERE bar = $(MyPlaceholder);
```

Currently TSQLLint throws a syntax error for files containing placeholders. This change adds support to TSQLLint for placeholder syntax by dereferencing any placeholders with values from environment variables before applying linting rules which enables use-cases like this:

```pwsh
Set-Content -Path query.sql -Value 'SELECT * FROM foo WHERE bar = $(MyPlaceholder);'

$env:MyPlaceholder = '123'

# this will run linting on the query SELECT * FROM foo WHERE bar = 123;
tsqllint query.sql
```