### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ TSQLLint rules may be set to "off", "warning", or "error". Rules that are violat
 
 To temporarily disable all rule warnings in a script, use comments in the following format:
 
-```sql
+```tsql
 /* tsqllint-disable */
 
 SELECT * FROM FOO;
@@ -128,7 +128,7 @@ SELECT * FROM FOO;
 
 To disable or enable warnings for specific rules:
 
-```sql
+```tsql
 /* tsqllint-disable select-star */
 
 SELECT * FROM FOO;
@@ -138,7 +138,7 @@ SELECT * FROM FOO;
 
 To disable warnings for the entire script, place a /* tsqllint-disable */ comment at the top of the file:
 
-```sql
+```tsql
 /* tsqllint-disable */
 
 SELECT * FROM FOO;
@@ -146,7 +146,7 @@ SELECT * FROM FOO;
 
 To disable specific rule warnings for the entire script place a comment similar to the following at the top of the file:
 
-```sql
+```tsql
 /* tsqllint-disable select-star */
 
 SELECT * FROM FOO;
@@ -171,7 +171,7 @@ Setting the compatability level within the `.tsqllintrc` file configures the def
 
 Setting the compatability level using inline comments configures the Compatability Level for just that file. Overrides should be placed at the top of files.
 
-```sql
+```tsql
 /* tsqllint-override compatability-level = 130 */
 
 SELECT * FROM FOO;
@@ -181,7 +181,7 @@ SELECT * FROM FOO;
 
 Many tools in the SQL ecosystem support placeholders to templatize SQL files as shown in the example below:
 
-```sql
+```tsql
 SELECT * FROM FOO WHERE BAR = '$(MyPlaceholderValue)';
 ```
 

--- a/documentation/rules/conditional-begin-end.md
+++ b/documentation/rules/conditional-begin-end.md
@@ -5,15 +5,15 @@
 Use BEGIN and END to bind conditional statments as a single block of code.
 
 Examples of **incorrect** code for this rule:
-        
-```sql
+
+```tsql
   IF (@parm = 1)
     SELECT @output = ‘foo’
 ```
 
 Examples of **correct** code for this rule:
 
-```sql
+```tsql
   IF (@parm = 1)
   BEGIN
     SELECT @output = ‘foo’

--- a/documentation/rules/cross-database-transaction.md
+++ b/documentation/rules/cross-database-transaction.md
@@ -1,12 +1,12 @@
-# Discourages inserts or updates that create transactions in more than one database.
+# Discourages inserts or updates that create transactions in more than one database
 
 ## Rule Details
 
 Cross database inserts or updates enclosed in a transaction can lead to data corruption
 
 Examples of **incorrect** code for this rule:
-        
-```sql
+
+```tsql
   BEGIN TRANSACTION;
     UPDATE DB1.dbo.Table1 SET Value = 1;
     UPDATE DB2.dbo.Table2 SET Value = 1;
@@ -15,12 +15,12 @@ Examples of **incorrect** code for this rule:
 
 Examples of **correct** code for this rule:
 
-```sql
+```tsql
   BEGIN TRANSACTION;
     UPDATE DB1.dbo.Table1 SET Value = 1;
   COMMIT TRANSACTION;
   
   BEGIN TRANSACTION;
     UPDATE DB2.dbo.Table2 SET Value = 1;
-  COMMIT TRANSACTION 
+  COMMIT TRANSACTION
 ```

--- a/documentation/rules/data-compression.md
+++ b/documentation/rules/data-compression.md
@@ -2,21 +2,21 @@
 
 ## Rule Details
 
-Data compression can reduce database size and can help improve performance of I/O intensive workloads 
+Data compression can reduce database size and can help improve performance of I/O intensive workloads
 
 Examples of **incorrect** code for this rule:
-        
-```sql
-  CREATE TABLE MyTable 
-	(ID INT, 
-	Name nvarchar(50))
+
+```tsql
+  CREATE TABLE MyTable
+    (ID INT,
+    Name nvarchar(50))
 ```
 
 Examples of **correct** code for this rule:
 
-```sql
-  CREATE TABLE MyTable 
-	(ID INT, 
-	Name nvarchar(50))
+```tsql
+  CREATE TABLE MyTable
+    (ID INT,
+    Name nvarchar(50))
   WITH (DATA_COMPRESSION = ROW);
 ```

--- a/documentation/rules/data-type-length.md
+++ b/documentation/rules/data-type-length.md
@@ -6,7 +6,7 @@ Use of length when specifying data types can help with database size and improve
 
 Examples of **incorrect** code for this rule:
 
-```sql
+```tsql
   CREATE TABLE MyTable
     (ID INT,
      Name nvarchar);
@@ -14,8 +14,8 @@ Examples of **incorrect** code for this rule:
 
 Examples of **correct** code for this rule:
 
-```sql
+```tsql
   CREATE TABLE MyTable
-	(ID INT,
-	Name nvarchar(50))
+  (ID INT,
+  Name nvarchar(50))
 ```

--- a/documentation/rules/disallow-cursors.md
+++ b/documentation/rules/disallow-cursors.md
@@ -6,15 +6,15 @@ Use of cursors introduces a pattern of row based operations, which less preferre
 
 Examples of **incorrect** code for this rule:
 
-```sql
-DECLARE @id int 
+```tsql
+DECLARE @id int
 DECLARE cursorT CURSOR
 FOR
 SELECT ProductId
 FROM AdventureWorks2012.Production.Product
 WHERE DaysToManufacture <= 1
- 
-OPEN cursorT 
+
+OPEN cursorT
 FETCH NEXT FROM cursorT INTO @id
 WHILE @@FETCH_STATUS = 0
 BEGIN
@@ -22,13 +22,13 @@ BEGIN
           WHERE ProductID=@id
           FETCH NEXT FROM cursorT INTO @id
 END
-CLOSE cursorT 
-DEALLOCATE cursorT 
+CLOSE cursorT
+DEALLOCATE cursorT
 ```
 
 Examples of **correct** code for this rule:
 
-```sql
+```tsql
 -- Alternative to cursor statement, using join
 
 SET STATISTICS TIME ON

--- a/documentation/rules/full-text.md
+++ b/documentation/rules/full-text.md
@@ -6,18 +6,17 @@ Use of improperly tuned full text queries can lead to performance problems
 
 Examples of **incorrect** code for this rule:
 
-```sql
+```tsql
 SELECT Name, ListPrice
 FROM Production.Product
 WHERE ListPrice = 80.99
    AND CONTAINS(Name, 'Mountain')
 GO
-
 ```
 
 Examples of **correct** code for this rule:
 
-```sql
+```tsql
 SELECT Name, ListPrice
 FROM Production.Product
 WHERE ListPrice = 80.99

--- a/documentation/rules/information-schema.md
+++ b/documentation/rules/information-schema.md
@@ -6,14 +6,14 @@ The INFORMATION_SCHEMA are not the best source for object metadata, use SYS.OBJE
 
 Examples of **incorrect** code for this rule:
 
-```sql
+```tsql
 SELECT table_name FROM INFORMATION_SCHEMA.TABLES
 WHERE table_schema = 'MyTable'
 ```
 
 Examples of **correct** code for this rule:
 
-```sql
+```tsql
 SELECT name
 FROM sys.objects
 WHERE OBJECTPROPERTY(object_id, N'SchemaId') = SCHEMA_ID(N'Production')

--- a/documentation/rules/keyword-capitalization.md
+++ b/documentation/rules/keyword-capitalization.md
@@ -4,12 +4,12 @@
 
 Capitalizing SQL keywords enhances readability and provides a clear seperation between keywords and objects
 
-```sql
+```tsql
 select * from foo;
 ```
 
 Examples of **correct** code for this rule:
 
-```sql
+```tsql
 SELECT * FROM foo;
 ```

--- a/documentation/rules/linked-server.md
+++ b/documentation/rules/linked-server.md
@@ -1,19 +1,19 @@
 # Disallows user of linked server calls
 
-# Rule Details
+## Rule Details
 
 This rule disallows linked server queries, which can cause table locking and are discouraged
 
 Examples of **incorrect** code for this rule:
 
-```sql
+```tsql
 SELECT Foo
 FROM MyServer.MyDatabase.MySchema.MyTable;
 ```
 
 Examples of **correct** code for this rule:
 
-```sql
+```tsql
 SELECT Foo
 FROM MyDatabase.MySchema.MyTable;
 ```

--- a/documentation/rules/multi-table-alias.md
+++ b/documentation/rules/multi-table-alias.md
@@ -10,7 +10,7 @@ Examples of **incorrect** code for this rule:
 ```tsql
 SELECT user_name, country_name
 FROM dbo.MyTable
-    INNER JOIN dbo.Country ON c.id = mt.country_id;
+    INNER JOIN dbo.Country ON id = country_id;
 ```
 
 Examples of **correct** code for this rule:

--- a/documentation/rules/multi-table-alias.md
+++ b/documentation/rules/multi-table-alias.md
@@ -1,0 +1,22 @@
+# Enforce aliasing in multi-table joins
+
+## Rule Details
+
+This rule enforces the use of table aliases
+when multiple tables are joined in a query.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SELECT user_name, country_name
+FROM dbo.MyTable
+    INNER JOIN dbo.Country ON c.id = mt.country_id;
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SELECT mt.user_name, c.country_name
+FROM dbo.MyTable AS mt
+    INNER JOIN dbo.Country AS c ON c.id = mt.country_id;
+```

--- a/documentation/rules/named-constraint.md
+++ b/documentation/rules/named-constraint.md
@@ -1,0 +1,22 @@
+# Disallows named constraints in temp tables
+
+## Rule Details
+
+This rule disallows named constraints in temporary tables, which can cause collisions when used in parallel.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+CREATE TABLE #temporary (
+    ID INT IDENTITY (1,1),
+    CreatedOn DATETIME2 NOT NULL
+        CONSTRAINT [df_CreatedOn] DEFAULT GETDATE());
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+CREATE TABLE #temporary (
+    ID INT IDENTITY (1,1),
+    CreatedOn DATETIME2 NOT NULL DEFAULT GETDATE());
+```

--- a/documentation/rules/non-sargable.md
+++ b/documentation/rules/non-sargable.md
@@ -1,0 +1,23 @@
+# Disallow functions on filter clauses or join predicates
+
+## Rule Details
+
+This rule disallows the use of functions on filter clauses
+and join predicates, which can negatively impact performance
+by making a query non-SARGable (Search ARGumentable).
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SELECT user_name
+FROM dbo.MyTable
+WHERE DATEDIFF(day, created_on, GETDATE()) <= 3;
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SELECT user_name
+FROM dbo.MyTable
+WHERE created_on >= DATEADD(day, -3, GETDATE());
+```

--- a/documentation/rules/object-property.md
+++ b/documentation/rules/object-property.md
@@ -1,0 +1,24 @@
+# Disallow using ObjectedProperty function over sys view
+
+## Rule Details
+
+This rule disallows using the `ObjectProperty` function
+when a sys view could be used instead.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+IF OBJECTPROPERTY(OBJECT_ID(N'dbo.MyTable'),'ISTABLE') = 1
+BEGIN
+   SELECT 'dbo.MyTable is a table';
+END
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+IF EXISTS (SELECT * FROM sys.tables WHERE name = 'MyTable')
+BEGIN
+   SELECT 'dbo.MyTable is a table';
+END
+```

--- a/documentation/rules/print-statement.md
+++ b/documentation/rules/print-statement.md
@@ -1,0 +1,17 @@
+# Disallow using PRINT statements
+
+## Rule Details
+
+This rule disallows using `PRINT` statements.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+PRINT 'This is a debug message.'
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+RAISERROR('This is a debug message.', 160, 1);
+```

--- a/documentation/rules/schema-qualify.md
+++ b/documentation/rules/schema-qualify.md
@@ -1,0 +1,20 @@
+# Enforce qualifying objects with schema name
+
+## Rule Details
+
+This rule enforces qualifying references to objects with
+schema names.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SELECT user_name
+FROM MyTable;
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SELECT user_name
+FROM dbo.MyTable;
+```

--- a/documentation/rules/select-star.md
+++ b/documentation/rules/select-star.md
@@ -1,0 +1,20 @@
+# Disallow selecting all columns with asterisk
+
+## Rule Details
+
+This rule disallows selecting all columns of a table
+by using an asterisk.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SELECT *
+FROM dbo.MyTable;
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SELECT user_id, user_name, created_on
+FROM dbo.MyTable;
+```

--- a/documentation/rules/semicolon-termination.md
+++ b/documentation/rules/semicolon-termination.md
@@ -1,0 +1,21 @@
+# Enforce terminating queries with semicolons
+
+## Rule Details
+
+This rule enforces termination of all queries with
+a semicolon, as defined by Microsoft's
+[Transact-SQL Syntax Conventions](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/transact-sql-syntax-conventions-transact-sql?view=sql-server-ver15)
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SELECT user_name
+FROM dbo.MyTable
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SELECT user_name
+FROM dbo.MyTable;
+```

--- a/documentation/rules/set-ansi.md
+++ b/documentation/rules/set-ansi.md
@@ -8,7 +8,8 @@ near the top of the file.
 Examples of **incorrect** code for this rule:
 
 ```tsql
-SET @MyVar VARCHAR(30) = 'This is incorrect.';
+DECLARE @MyVar VARCHAR(30);
+SELECT @MyVar = 'This is incorrect.';
 ```
 
 Examples of **correct** code for this rule:
@@ -17,5 +18,6 @@ Examples of **correct** code for this rule:
 SET ANSI_NULLS ON;
 GO
 
-SELECT @MyVar VARCHAR(30) = 'This is correct.';
+DECLARE @MyVar VARCHAR(30);
+SELECT @MyVar = 'This is correct.';
 ```

--- a/documentation/rules/set-ansi.md
+++ b/documentation/rules/set-ansi.md
@@ -1,0 +1,21 @@
+# Enforce setting SET ANSI_NULLS ON near top of file
+
+## Rule Details
+
+This rule enforces setting `SET ANSI_NULLS ON`
+near the top of the file.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SET @MyVar VARCHAR(30) = 'This is incorrect.';
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SET ANSI_NULLS ON;
+GO
+
+SELECT @MyVar VARCHAR(30) = 'This is correct.';
+```

--- a/documentation/rules/set-nocount.md
+++ b/documentation/rules/set-nocount.md
@@ -8,7 +8,8 @@ near the top of the file.
 Examples of **incorrect** code for this rule:
 
 ```tsql
-SET @MyVar VARCHAR(30) = 'This is incorrect.';
+DECLARE @MyVar VARCHAR(30);
+SELECT @MyVar = 'This is incorrect.';
 ```
 
 Examples of **correct** code for this rule:
@@ -16,5 +17,6 @@ Examples of **correct** code for this rule:
 ```tsql
 SET NOCOUNT ON;
 
-SELECT @MyVar VARCHAR(30) = 'This is correct.';
+DECLARE @MyVar VARCHAR(30);
+SELECT @MyVar = 'This is correct.';
 ```

--- a/documentation/rules/set-nocount.md
+++ b/documentation/rules/set-nocount.md
@@ -1,0 +1,20 @@
+# Enforce setting SET NOCOUNT ON near top of file
+
+## Rule Details
+
+This rule enforces setting `SET NOCOUNT ON`
+near the top of the file.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SET @MyVar VARCHAR(30) = 'This is incorrect.';
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SET NOCOUNT ON;
+
+SELECT @MyVar VARCHAR(30) = 'This is correct.';
+```

--- a/documentation/rules/set-quoted-identifier.md
+++ b/documentation/rules/set-quoted-identifier.md
@@ -8,7 +8,8 @@ near the top of the file.
 Examples of **incorrect** code for this rule:
 
 ```tsql
-SET @MyVar = 'This is incorrect.';
+DECLARE @MyVar VARCHAR(30);
+SELECT @MyVar = 'This is incorrect.';
 ```
 
 Examples of **correct** code for this rule:
@@ -17,5 +18,6 @@ Examples of **correct** code for this rule:
 SET QUOTED_IDENTIFIER ON;
 GO
 
+DECLARE @MyVar VARCHAR(30);
 SELECT @MyVar = 'This is correct.';
 ```

--- a/documentation/rules/set-quoted-identifier.md
+++ b/documentation/rules/set-quoted-identifier.md
@@ -1,0 +1,21 @@
+# Enforce setting SET QUOTED_IDENTIFIER ON near top of file
+
+## Rule Details
+
+This rule enforces setting `SET QUOTED_IDENTIFIER ON`
+near the top of the file.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SET @MyVar = 'This is incorrect.';
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SET QUOTED_IDENTIFIER ON;
+GO
+
+SELECT @MyVar = 'This is correct.';
+```

--- a/documentation/rules/set-transaction-isolation-level.md
+++ b/documentation/rules/set-transaction-isolation-level.md
@@ -1,0 +1,20 @@
+# Enforce setting SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED near top of file
+
+## Rule Details
+
+This rule enforces setting `SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED` near the top of a file.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SET @MyVar = 'This is incorrect.';
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+GO
+
+SELECT @MyVar = 'This is correct.';
+```

--- a/documentation/rules/set-transaction-isolation-level.md
+++ b/documentation/rules/set-transaction-isolation-level.md
@@ -7,7 +7,8 @@ This rule enforces setting `SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED` ne
 Examples of **incorrect** code for this rule:
 
 ```tsql
-SET @MyVar = 'This is incorrect.';
+DECLARE @MyVar VARCHAR(30);
+SELECT @MyVar = 'This is incorrect.';
 ```
 
 Examples of **correct** code for this rule:
@@ -16,5 +17,6 @@ Examples of **correct** code for this rule:
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 GO
 
+DECLARE @MyVar VARCHAR(30);
 SELECT @MyVar = 'This is correct.';
 ```

--- a/documentation/rules/set-variable.md
+++ b/documentation/rules/set-variable.md
@@ -8,11 +8,13 @@ using a `SELECT` statement.
 Examples of **incorrect** code for this rule:
 
 ```tsql
-SET @MyVar VARCHAR(30) = 'This is incorrect.';
+DECLARE @MyVar VARCHAR(30);
+SET @MyVar = 'This is incorrect.';
 ```
 
 Examples of **correct** code for this rule:
 
 ```tsql
-SELECT @MyVar VARCHAR(30) = 'This is correct.';
+DECLARE @MyVar VARCHAR(30);
+SELECT @MyVar = 'This is correct.';
 ```

--- a/documentation/rules/set-variable.md
+++ b/documentation/rules/set-variable.md
@@ -1,0 +1,18 @@
+# Enforce setting variable with SELECT statement
+
+## Rule Details
+
+This rule enforces setting variable values
+using a `SELECT` statement.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SET @MyVar VARCHAR(30) = 'This is incorrect.';
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SELECT @MyVar VARCHAR(30) = 'This is correct.';
+```

--- a/documentation/rules/unicode-string.md
+++ b/documentation/rules/unicode-string.md
@@ -1,0 +1,21 @@
+# Disallow use of unicode chars in non-unicode string
+
+## Rule Details
+
+This rule disallows using unicode characters in
+strings that do not support unicode characters.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SET @MyVar VARCHAR(30) = '¡This is incorrect!';
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+GO
+
+SELECT @MyVar NVARCHAR(30) = '¡This is correct!';
+```

--- a/documentation/rules/unicode-string.md
+++ b/documentation/rules/unicode-string.md
@@ -8,14 +8,11 @@ strings that do not support unicode characters.
 Examples of **incorrect** code for this rule:
 
 ```tsql
-SET @MyVar VARCHAR(30) = '¡This is incorrect!';
+DECLARE @MyVar VARCHAR(30) = 'Ⱦhis is incorrect.';
 ```
 
 Examples of **correct** code for this rule:
 
 ```tsql
-SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-GO
-
-SELECT @MyVar NVARCHAR(30) = '¡This is correct!';
+DECLARE @MyVar NVARCHAR(30) = N'Ⱦhis is correct.';
 ```

--- a/documentation/rules/upper-lower.md
+++ b/documentation/rules/upper-lower.md
@@ -1,0 +1,23 @@
+# Disallow using UPPER/LOWER functions in comparisons
+
+## Rule Details
+
+This rule disallows using `UPPER` or `LOWER` functions
+when performing comparisons since this is not required
+in case insensitive databases and can affect query SARGability.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SELECT user_name
+FROM dbo.MyTable
+WHERE UPPER(first_name) = 'NATHAN';
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SELECT user_name
+FROM dbo.MyTable
+WHERE first_name = 'NATHAN';
+```


### PR DESCRIPTION
Closes #219 

Also adjusted existing docs for markdown formatting best practices & switched code blocks to `tsql` from `sql` for better syntax highlighting. 