### PR TITLE
Plugins support default `RuleSeverity` value and use applications TSQLParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Before applying any linting rules, TSQLLint will replace any placeholder in a SQ
 
 ## Plugins
 
-You can extend the base functionality of TSQLLint by creating a custom plugin. TSQLLint plugins are Dotnet assemblies that implement the IPlugin interface from [TSQLLint.Common](https://www.nuget.org/packages/TSQLLint.Common/). Ensure the plugin is targeting `netcoreapp2.0`.
+You can extend the base functionality of TSQLLint by creating a custom plugin. TSQLLint plugins are Dotnet assemblies that implement the IPlugin interface from [TSQLLint.Common](https://www.nuget.org/packages/TSQLLint.Common/). Ensure the plugin is targeting `net6.0`.
 
 After developing the plugin, update the .tsqllintrc file to point to its `.dll`.
 
@@ -235,13 +235,16 @@ This sample plugin notifies users that spaces should be used rather than tabs.
 
 ```csharp
 using System;
-using TSQLLint.Common;
+using System.Collections.Generic;
 using System.IO;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using TSQLLint.Common;
 
-namespace TSQLLint.Tests.UnitTests.PluginHandler
+namespace TSQLLint_Sample_Plugin
 {
     public class SamplePlugin : IPlugin
     {
+        // This method is required but can be a no-op if using the GetRules method to parse code through the plugin's rules.
         public void PerformAction(IPluginContext context, IReporter reporter)
         {
             string line;
@@ -262,13 +265,19 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                     RuleViolationSeverity.Warning));
             }
         }
+
+        // Starting with TSQLLint.Common version 3.3.0, this method can be used to return rules to be used by the TSQLLint parser.
+        public IDictionary<string, ISqlLintRule> GetRules() => new Dictionary<string, ISqlLintRule>
+        {
+            ["sample-plugin-rule"] = new SampleRule((Action<string, string, int, int>)null)
+        };
     }
 
     class SampleRuleViolation : IRuleViolation
     {
-        public int Column { get; private set; }
+        public int Column { get; set; }
         public string FileName { get; private set; }
-        public int Line { get; private set; }
+        public int Line { get; set; }
         public string RuleName { get; private set; }
         public RuleViolationSeverity Severity { get; private set; }
         public string Text { get; private set; }
@@ -281,6 +290,35 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             Line = lineNumber;
             Column = column;
             Severity = ruleViolationSeverity;
+        }
+    }
+
+    class SampleRule : TSqlFragmentVisitor, ISqlLintRule
+    {
+        protected readonly Action<string, string, int, int> ErrorCallback;
+
+        public SampleRule(Action<string, string, int, int> errorCallback)
+        {
+            ErrorCallback = errorCallback;
+        }
+
+        public string RULE_NAME => "sample-plugin-rule";
+        public string RULE_TEXT => "Sample plugin rule message text";
+        public RuleViolationSeverity RULE_SEVERITY => RuleViolationSeverity.Warning;
+
+        public override void Visit(TSqlScript node)
+        {
+            var line = 0;
+            var column = 0;
+
+            // Logic for testing TSQL code for rule goes here.
+
+            ErrorCallback(RULE_NAME, RULE_TEXT, line, column);
+        }
+
+        public void FixViolation(List<string> fileLines, IRuleViolation ruleViolation, FileLineActions actions)
+        {
+            // Logic for fixing rule violation goes here.
         }
     }
 }

--- a/source/TSQLLint.Core/Interfaces/IConfigReader.cs
+++ b/source/TSQLLint.Core/Interfaces/IConfigReader.cs
@@ -13,7 +13,7 @@ namespace TSQLLint.Core.Interfaces
 
         Dictionary<string, string> GetPlugins();
 
-        RuleViolationSeverity GetRuleSeverity(string key);
+        RuleViolationSeverity GetRuleSeverity(string key, RuleViolationSeverity defaultValue = RuleViolationSeverity.Off);
 
         void ListPlugins();
 

--- a/source/TSQLLint.Core/TSQLLint.Core.csproj
+++ b/source/TSQLLint.Core/TSQLLint.Core.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TSQLLint.Common" Version="3.2.0" />
+    <PackageReference Include="TSQLLint.Common" Version="3.3.0" />
   </ItemGroup>
 
 </Project>

--- a/source/TSQLLint.Infrastructure/Configuration/ConfigReader.cs
+++ b/source/TSQLLint.Infrastructure/Configuration/ConfigReader.cs
@@ -55,9 +55,9 @@ namespace TSQLLint.Infrastructure.Configuration
             }
         }
 
-        public RuleViolationSeverity GetRuleSeverity(string key)
+        public RuleViolationSeverity GetRuleSeverity(string key, RuleViolationSeverity defaultValue = RuleViolationSeverity.Off)
         {
-            return configuredRules.TryGetValue(key, out var ruleValue) ? ruleValue : RuleViolationSeverity.Off;
+            return configuredRules.TryGetValue(key, out var ruleValue) ? ruleValue : defaultValue;
         }
 
         public Dictionary<string, string> GetPlugins()

--- a/source/TSQLLint.Infrastructure/Plugins/PluginHandler.cs
+++ b/source/TSQLLint.Infrastructure/Plugins/PluginHandler.cs
@@ -107,19 +107,12 @@ namespace TSQLLint.Infrastructure.Plugins
 
                 if (!List.ContainsKey(type))
                 {
-                    List.Add(type, (IPlugin)Activator.CreateInstance(type));
+                    var plugin = (IPlugin)Activator.CreateInstance(type);
+                    List.Add(type, plugin);
                     var version = versionWrapper.GetVersion(dll);
                     reporter.Report($"Loaded plugin: '{type.FullName}', Version: '{version}'");
-                }
-                else
-                {
-                    reporter.Report($"Already loaded plugin with type '{type.FullName}'");
-                }
 
-                if (inerfaces.Contains(typeof(IPluginWithRules)))
-                {
-                    var plugin = (IPluginWithRules)Activator.CreateInstance(type);
-                    foreach (var rule in plugin.Rules)
+                    foreach (var rule in plugin.GetRules())
                     {
                         try
                         {
@@ -127,10 +120,14 @@ namespace TSQLLint.Infrastructure.Plugins
                         }
                         catch (Exception exception)
                         {
-                            reporter.Report($"There was a problem with plugin: {plugin.GetType().FullName} - {exception.Message}");
+                            reporter.Report($"There was a problem with plugin: {type.FullName} - {exception.Message}");
                             Trace.WriteLine(exception);
                         }
                     }
+                }
+                else
+                {
+                    reporter.Report($"Already loaded plugin with type '{type.FullName}'");
                 }
             }
         }

--- a/source/TSQLLint.Infrastructure/Rules/Common/BaseRuleVisitor.cs
+++ b/source/TSQLLint.Infrastructure/Rules/Common/BaseRuleVisitor.cs
@@ -10,7 +10,7 @@ namespace TSQLLint.Infrastructure.Rules.Common
     {
         protected readonly Action<string, string, int, int> errorCallback;
 
-        public BaseRuleVisitor(Action<string, string, int, int> errorCallback)
+        protected BaseRuleVisitor(Action<string, string, int, int> errorCallback)
         {
             this.errorCallback = errorCallback;
         }
@@ -19,6 +19,7 @@ namespace TSQLLint.Infrastructure.Rules.Common
         public int DynamicSqlStartLine { get; set; }
         public abstract string RULE_NAME { get; }
         public abstract string RULE_TEXT { get; }
+        public RuleViolationSeverity RULE_SEVERITY => RuleViolationSeverity.Off;
 
         public virtual void FixViolation(
             List<string> fileLines, IRuleViolation ruleViolation, FileLineActions actions)

--- a/source/TSQLLint.Infrastructure/TSQLLint.Infrastructure.csproj
+++ b/source/TSQLLint.Infrastructure/TSQLLint.Infrastructure.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="160.5400.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="TSQLLint.Common" Version="3.2.0" />
+    <PackageReference Include="TSQLLint.Common" Version="3.3.0" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.3" />
   </ItemGroup>
 

--- a/source/TSQLLint.Infrastructure/TSQLLint.Infrastructure.csproj
+++ b/source/TSQLLint.Infrastructure/TSQLLint.Infrastructure.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="160.5400.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="TSQLLint.Common" Version="3.3.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="17.0.3" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.0.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/TSQLLint.Tests/TSQLLint.Tests.csproj
+++ b/source/TSQLLint.Tests/TSQLLint.Tests.csproj
@@ -7,16 +7,16 @@
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Abstractions" Version="17.0.3" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.0.3" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.0.24" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.0.24" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>

--- a/source/TSQLLint.Tests/UnitTests/LintingRuleVisitorBuilder/RuleVisitorBuilderIgnoreRulesTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/LintingRuleVisitorBuilder/RuleVisitorBuilderIgnoreRulesTests.cs
@@ -29,7 +29,7 @@ namespace TSQLLint.Tests.UnitTests.LintingRuleVisitorBuilder
             var ignoredRuleList = new List<IExtendedRuleException>();
 
             var pathString = "DoesntExist.sql";
-            var ruleVisitorBuilder = new RuleVisitorBuilder(mockConfigReader, mockReporter);
+            var ruleVisitorBuilder = new RuleVisitorBuilder(mockConfigReader, mockReporter, RuleVisitorFriendlyNameTypeMap.Rules);
             var activeRuleVisitors = ruleVisitorBuilder.BuildVisitors(pathString, ignoredRuleList);
             var testFileStream = ParsingUtility.GenerateStreamFromString("SELECT * FROM FOO;");
             var textReader = new StreamReader(testFileStream);
@@ -68,7 +68,7 @@ namespace TSQLLint.Tests.UnitTests.LintingRuleVisitorBuilder
             };
 
             var pathString = "DoesntExist.sql";
-            var ruleVisitorBuilder = new RuleVisitorBuilder(mockConfigReader, mockReporter);
+            var ruleVisitorBuilder = new RuleVisitorBuilder(mockConfigReader, mockReporter, RuleVisitorFriendlyNameTypeMap.Rules);
             var activeRuleVisitors = ruleVisitorBuilder.BuildVisitors(pathString, ignoredRuleList);
             var testFileStream = ParsingUtility.GenerateStreamFromString("SELECT * FROM FOO;");
             var textReader = new StreamReader(testFileStream);
@@ -104,7 +104,7 @@ namespace TSQLLint.Tests.UnitTests.LintingRuleVisitorBuilder
             };
 
             var pathString = "DoesntExist.sql";
-            var ruleVisitorBuilder = new RuleVisitorBuilder(mockConfigReader, mockReporter);
+            var ruleVisitorBuilder = new RuleVisitorBuilder(mockConfigReader, mockReporter, RuleVisitorFriendlyNameTypeMap.Rules);
             var activeRuleVisitors = ruleVisitorBuilder.BuildVisitors(pathString, ignoredRuleList);
             var testFileStream = ParsingUtility.GenerateStreamFromString("SELECT * FROM FOO");
             var textReader = new StreamReader(testFileStream);

--- a/source/TSQLLint.Tests/UnitTests/LintingRuleVisitorBuilder/RuleVisitorBuilderTest.cs
+++ b/source/TSQLLint.Tests/UnitTests/LintingRuleVisitorBuilder/RuleVisitorBuilderTest.cs
@@ -8,6 +8,7 @@ using TSQLLint.Common;
 using TSQLLint.Core.Interfaces;
 using TSQLLint.Infrastructure.Configuration;
 using TSQLLint.Infrastructure.Parser;
+using TSQLLint.Tests.UnitTests.PluginHandler;
 
 namespace TSQLLint.Tests.UnitTests.LintingRuleVisitorBuilder
 {
@@ -38,11 +39,15 @@ namespace TSQLLint.Tests.UnitTests.LintingRuleVisitorBuilder
 
             var configReader = new ConfigReader(reporter, fileSystem, environmentWrapper);
             configReader.LoadConfig(configFilePath);
-            var ruleVisitorBuilder = new RuleVisitorBuilder(configReader, null);
+
+            var rules = RuleVisitorFriendlyNameTypeMap.Rules;
+            rules.Add("plugin-rule", new TestPluginRule(null));
+
+            var ruleVisitorBuilder = new RuleVisitorBuilder(configReader, reporter, rules);
 
             var ignoredRuleList = new List<IExtendedRuleException>();
             var activeRuleVisitors = ruleVisitorBuilder.BuildVisitors("foo.sql", ignoredRuleList);
-            Assert.AreEqual(2, activeRuleVisitors.Count);
+            Assert.AreEqual(3, activeRuleVisitors.Count);
         }
     }
 }

--- a/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPluginRule.cs
+++ b/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPluginRule.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using TSQLLint.Common;
+using TSQLLint.Core.Interfaces;
+
+namespace TSQLLint.Tests.UnitTests.PluginHandler
+{
+    [ExcludeFromCodeCoverage]
+    public class TestPluginRule : TSqlFragmentVisitor, ISqlRule
+    {
+        private readonly Action<string, string, int, int> errorCallback;
+
+        public TestPluginRule(Action<string, string, int, int> errorCallback)
+        {
+            this.errorCallback = errorCallback;
+        }
+
+        public string RULE_NAME => "plugin-rule";
+
+        public string RULE_TEXT => "Plugin rule failed";
+
+        public int DynamicSqlStartColumn { get; set; }
+
+        public int DynamicSqlStartLine { get; set; }
+
+        public RuleViolationSeverity RULE_SEVERITY => RuleViolationSeverity.Error;
+
+        public void FixViolation(List<string> fileLines, IRuleViolation ruleViolation, FileLineActions actions)
+        {
+        }
+    }
+}

--- a/source/TSQLLint/Application.cs
+++ b/source/TSQLLint/Application.cs
@@ -58,9 +58,9 @@ namespace TSQLLint
                 do
                 {
                     var fragmentBuilder = new FragmentBuilder(configReader.CompatabilityLevel);
-                    var ruleVisitorBuilder = new RuleVisitorBuilder(configReader, this.reporter);
-                    var ruleVisitor = new SqlRuleVisitor(ruleVisitorBuilder, fragmentBuilder, reporter);
                     var rules = RuleVisitorFriendlyNameTypeMap.Rules;
+                    var ruleVisitorBuilder = new RuleVisitorBuilder(configReader, this.reporter, rules);
+                    var ruleVisitor = new SqlRuleVisitor(ruleVisitorBuilder, fragmentBuilder, reporter);
                     pluginHandler = new PluginHandler(reporter, rules);
                     pluginHandler.ProcessPaths(configReader.GetPlugins());
                     fileProcessor = new SqlFileProcessor(

--- a/source/TSQLLint/TSQLLint.csproj
+++ b/source/TSQLLint/TSQLLint.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TSQLLint.Common" Version="3.2.0" />
+    <PackageReference Include="TSQLLint.Common" Version="3.3.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
   </ItemGroup>
 


### PR DESCRIPTION
- Make all rules that go to `RuleVisitorBuilder`.
- Updated to retrieve `RuleViolationSeverity` from `ISqlLintRule`.
- Updated code to not use `IPluginWithRules` and use new `IPlugin.GetRules` method.
- Updated `TSQLLint.Common` to version `3.3.0`.
- Updated some Nuget dependencies that were either minor or patch updates.
- Updated Readme file to include updated plugin example code.