### PR TITLE
Fixed misspelled "compatability-level" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Setting the compatibility level within the `.tsqllintrc` file configures the def
   "rules": {
     "upper-lower": "error"
   },
-  "compatability-level": 90
+  "compatibility-level": 90
 }
 ```
 
@@ -198,7 +198,7 @@ Setting the compatibility level within the `.tsqllintrc` file configures the def
 Setting the compatibility level using inline comments configures the Compatibility Level for just that file. Overrides should be placed at the top of files.
 
 ```tsql
-/* tsqllint-override compatability-level = 130 */
+/* tsqllint-override compatibility-level = 130 */
 
 SELECT * FROM FOO;
 ```

--- a/source/TSQLLint.Infrastructure/Configuration/ConfigFileGenerator.cs
+++ b/source/TSQLLint.Infrastructure/Configuration/ConfigFileGenerator.cs
@@ -39,7 +39,7 @@ namespace TSQLLint.Infrastructure.Configuration
         ""update-where"" : ""error"",
         ""upper-lower"": ""error""
     },
-    ""compatability-level"": 120
+    ""compatibility-level"": 120
 }";
 
         private readonly IFileSystem fileSystem;

--- a/source/TSQLLint.Infrastructure/Configuration/ConfigReader.cs
+++ b/source/TSQLLint.Infrastructure/Configuration/ConfigReader.cs
@@ -169,7 +169,7 @@ namespace TSQLLint.Infrastructure.Configuration
 
         private void SetupParser(JToken jsonObject)
         {
-            var compatabilityLevel = jsonObject.SelectTokens("..compatability-level").FirstOrDefault()?.ToString();
+            var compatabilityLevel = (jsonObject.SelectTokens("..compatibility-level").FirstOrDefault() ?? jsonObject.SelectTokens("..compatability-level").FirstOrDefault())?.ToString();
             int.TryParse(compatabilityLevel, out var parsedCompatabilityLevel);
             CompatabilityLevel = Core.CompatabilityLevel.Validate(parsedCompatabilityLevel);
         }

--- a/source/TSQLLint.Infrastructure/Configuration/Overrides/OverrideTypeMap.cs
+++ b/source/TSQLLint.Infrastructure/Configuration/Overrides/OverrideTypeMap.cs
@@ -7,6 +7,8 @@ namespace TSQLLint.Infrastructure.Configuration.Overrides
     {
         public static readonly Dictionary<string, Type> List = new Dictionary<string, Type>
         {
+            { "compatibility-level", typeof(OverrideCompatabilityLevel) },
+            // Deprecate usage of misspelled "compatability-level".
             { "compatability-level", typeof(OverrideCompatabilityLevel) }
         };
     }

--- a/source/TSQLLint.Tests/UnitTests/ConfigFile/ConfigReaderTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/ConfigFile/ConfigReaderTests.cs
@@ -221,6 +221,63 @@ namespace TSQLLint.Tests.UnitTests.ConfigFile
             Assert.IsTrue(configReader.IsConfigLoaded);
         }
 
+        // Test misspelled "compatability-level"
+        [Test]
+        public void ConfigReaderGetParserFromValidIntOld()
+        {
+            // arrange
+            var configFilePath = TestHelper.GetTestFilePath(@"C:\Users\User\.tsqllintrc");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    configFilePath, new MockFileData(@"
+                    {
+                        'compatability-level': 120
+                    }")
+                }
+            });
+
+            var mockReporter = Substitute.For<IReporter>();
+            var environmentWrapper = Substitute.For<IEnvironmentWrapper>();
+
+            // act
+            var configReader = new ConfigReader(mockReporter, mockFileSystem, environmentWrapper);
+            configReader.LoadConfig(configFilePath);
+
+            // assert
+            Assert.IsTrue(configReader.IsConfigLoaded);
+            Assert.AreEqual(120, configReader.CompatabilityLevel);
+        }
+
+        // Test misspelled "compatability-level" with correctly spelled "compatibility-level"
+        [Test]
+        public void ConfigReaderGetParserFromValidIntFallback()
+        {
+            // arrange
+            var configFilePath = TestHelper.GetTestFilePath(@"C:\Users\User\.tsqllintrc");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    configFilePath, new MockFileData(@"
+                    {
+                        'compatability-level': 120,
+                        'compatibility-level': 130
+                    }")
+                }
+            });
+
+            var mockReporter = Substitute.For<IReporter>();
+            var environmentWrapper = Substitute.For<IEnvironmentWrapper>();
+
+            // act
+            var configReader = new ConfigReader(mockReporter, mockFileSystem, environmentWrapper);
+            configReader.LoadConfig(configFilePath);
+
+            // assert
+            Assert.IsTrue(configReader.IsConfigLoaded);
+            Assert.AreEqual(130, configReader.CompatabilityLevel);
+        }
+
         [Test]
         public void ConfigReaderGetParserFromValidInt()
         {
@@ -231,7 +288,7 @@ namespace TSQLLint.Tests.UnitTests.ConfigFile
                 {
                     configFilePath, new MockFileData(@"
                     {
-                        'compatability-level': 120
+                        'compatibility-level': 120
                     }")
                 }
             });
@@ -258,7 +315,7 @@ namespace TSQLLint.Tests.UnitTests.ConfigFile
                 {
                     configFilePath, new MockFileData(@"
                     {
-                        'compatability-level': '130'
+                        'compatibility-level': '130'
                     }")
                 }
             });
@@ -285,7 +342,7 @@ namespace TSQLLint.Tests.UnitTests.ConfigFile
                 {
                     configFilePath, new MockFileData(@"
                     {
-                        'compatability-level': 10
+                        'compatibility-level': 10
                     }")
                 }
             });
@@ -312,7 +369,7 @@ namespace TSQLLint.Tests.UnitTests.ConfigFile
                 {
                     configFilePath, new MockFileData(@"
                     {
-                        'compatability-level': 'foo'
+                        'compatibility-level': 'foo'
                     }")
                 }
             });

--- a/source/TSQLLint.Tests/UnitTests/ConfigFile/Overrides/OverrideTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/ConfigFile/Overrides/OverrideTests.cs
@@ -13,6 +13,7 @@ namespace TSQLLint.Tests.UnitTests.ConfigFile.Overrides
     {
         private static readonly object[] TestCases =
         {
+            // Test misspelled "compatability-level"
             new object[]
             {
                 "valid compatability-level override",
@@ -21,25 +22,31 @@ namespace TSQLLint.Tests.UnitTests.ConfigFile.Overrides
             },
             new object[]
             {
-                "valid compatability-level override and unsupported 'foo' override",
-                @"/* tsqllint-override compatability-level = 90, foo = bar */",
+                "valid compatibility-level override",
+                @"/* tsqllint-override compatibility-level = 130 */",
+                new List<IOverride> { new OverrideCompatabilityLevel("130") }
+            },
+            new object[]
+            {
+                "valid compatibility-level override and unsupported 'foo' override",
+                @"/* tsqllint-override compatibility-level = 90, foo = bar */",
                 new List<IOverride> { new OverrideCompatabilityLevel("90") }
             },
             new object[]
             {
-                "valid compatability-level override within multiline comment block",
+                "valid compatibility-level override within multiline comment block",
                 @"/* 
                    tsqllint-disable select-star
-                   tsqllint-override compatability-level = 80 
+                   tsqllint-override compatibility-level = 80 
                 */",
                 new List<IOverride> { new OverrideCompatabilityLevel("80") }
             },
             new object[]
             {
-                "valid compatability-level and unsupported override override within multiline comment block",
+                "valid compatibility-level and unsupported override override within multiline comment block",
                 @"/* 
                    tsqllint-disable select-star
-                   tsqllint-override compatability-level = 80, foo = bar 
+                   tsqllint-override compatibility-level = 80, foo = bar 
                 */",
                 new List<IOverride> { new OverrideCompatabilityLevel("80") }
             }

--- a/source/TSQLLint.Tests/UnitTests/LintingRuleExceptions/RuleExceptionFinderOverrideFinderIntegrationTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/LintingRuleExceptions/RuleExceptionFinderOverrideFinderIntegrationTests.cs
@@ -32,6 +32,7 @@ namespace TSQLLint.Tests.UnitTests.LintingRuleExceptions
             },
             new object[]
             {
+                // Test misspelled "compatability-level"
                 "valid compatability-level override",
                 @"/*
                     tsqllint-override compatability-level = 100
@@ -44,10 +45,22 @@ namespace TSQLLint.Tests.UnitTests.LintingRuleExceptions
             },
             new object[]
             {
-                "valid compatability-level override, ignore multiple rules",
+                "valid compatibility-level override",
+                @"/*
+                    tsqllint-override compatibility-level = 100
+                    tsqllint-disable select-star
+                  */
+                        SELECT * FROM FOO:
+                  */ tsqllint-enable select-star */",
+                new List<IExtendedRuleException> { new RuleException(typeof(SelectStarRule), "select-star", 3, 6) },
+                new List<IOverride> { new OverrideCompatabilityLevel("100") }
+            },
+            new object[]
+            {
+                "valid compatibility-level override, ignore multiple rules",
                 @"/*
                     tsqllint-disable select-star set-ansi
-                    tsqllint-override compatability-level = 110
+                    tsqllint-override compatibility-level = 110
                   */
                         SELECT * FROM FOO:
                   */ tsqllint-enable: select-star */",

--- a/source/TSQLLint.Tests/UnitTests/Parser/InlineOverride_Tests.cs
+++ b/source/TSQLLint.Tests/UnitTests/Parser/InlineOverride_Tests.cs
@@ -15,10 +15,18 @@ namespace TSQLLint.Tests.UnitTests.Parser
     {
         private static readonly object[] TestCases =
         {
+            // Test misspelled "compatability-level"
+            new object[]
+            {
+                "Compatibility Level Override Old",
+                @"/* tsqllint-override compatability-level = 130 */
+                  SELECT * FROM FOO;",
+                1
+            },
             new object[]
             {
                 "Compatibility Level Override",
-                @"/* tsqllint-override compatability-level = 130 */
+                @"/* tsqllint-override compatibility-level = 130 */
                   SELECT * FROM FOO;",
                 1
             },
@@ -31,7 +39,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             new object[]
             {
                 "Malformed Override",
-                @"/* tsqllint-overrides compatability-level = 130 */
+                @"/* tsqllint-overrides compatibility-level = 130 */
                   SELECT * FROM FOO;",
                 0
             }


### PR DESCRIPTION
- Added check for correctly spelled "compatibility-level" property with a fallback to the misspelled "compatability-level" property.