### PR TITLE
fix-dynamic-sql-plugin-rules - Fix casting issue when parsing dynamic sql with a plugin with rules loaded.

### DIFF
--- a/source/TSQLLint.Infrastructure/Parser/SqlRuleVisitor.cs
+++ b/source/TSQLLint.Infrastructure/Parser/SqlRuleVisitor.cs
@@ -80,11 +80,11 @@ namespace TSQLLint.Infrastructure.Parser
 
         private static bool VisitorIsBlackListedForDynamicSql(TSqlFragmentVisitor visitor)
         {
-            if (visitor == null)
+            if (visitor is not ISqlRule)
             {
                 return false;
             }
-            
+
             return new List<string>
             {
                 "SetAnsiNullsRule",

--- a/source/TSQLLint.Tests/FunctionalTests/ConsoleAppTests.cs
+++ b/source/TSQLLint.Tests/FunctionalTests/ConsoleAppTests.cs
@@ -116,6 +116,7 @@ namespace TSQLLint.Tests.FunctionalTests
 
         [TestCase(@"TestFiles/with-tabs.sql", "prefer-tabs : Should use spaces rather than tabs", 0)]
         [TestCase(@"TestFiles/with-spaces.sql", "Loaded plugin: 'TSQLLint.Tests.UnitTests.PluginHandler.TestPlugin'", 0)]
+        [TestCase(@"TestFiles/with-dynamic-sql.sql", "select-star : Expected column names in SELECT", 0)]
         public void LoadPluginTest(string testFile, string expectedMessage, int expectedExitCode)
         {
             var pluginLoaded = false;

--- a/source/TSQLLint.Tests/FunctionalTests/TestFiles/with-dynamic-sql.sql
+++ b/source/TSQLLint.Tests/FunctionalTests/TestFiles/with-dynamic-sql.sql
@@ -1,0 +1,1 @@
+EXEC (N'SELECT * FROM BAR;');

--- a/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPlugin.cs
+++ b/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPlugin.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using TSQLLint.Common;
 
@@ -29,5 +30,10 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                 }
             }
         }
+
+        public IDictionary<string, ISqlLintRule> GetRules() => new Dictionary<string, ISqlLintRule>
+        {
+            ["plugin-rule"] = new TestPluginRule(null)
+        };
     }
 }

--- a/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPluginRule.cs
+++ b/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPluginRule.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using TSQLLint.Common;
-using TSQLLint.Core.Interfaces;
 
 namespace TSQLLint.Tests.UnitTests.PluginHandler
 {
     [ExcludeFromCodeCoverage]
-    public class TestPluginRule : TSqlFragmentVisitor, ISqlRule
+    public class TestPluginRule : TSqlFragmentVisitor, ISqlLintRule
     {
         private readonly Action<string, string, int, int> errorCallback;
 
@@ -20,10 +19,6 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
         public string RULE_NAME => "plugin-rule";
 
         public string RULE_TEXT => "Plugin rule failed";
-
-        public int DynamicSqlStartColumn { get; set; }
-
-        public int DynamicSqlStartLine { get; set; }
 
         public RuleViolationSeverity RULE_SEVERITY => RuleViolationSeverity.Error;
 


### PR DESCRIPTION
- Fixed issue where if a file was parsed with dynamic sql having a plugin with rules loaded a casting exception would be thrown.