### PR TITLE
Standardize period use in console output

### DIFF
--- a/source/TSQLLint.Infrastructure/Reporters/ConsoleReporter.cs
+++ b/source/TSQLLint.Infrastructure/Reporters/ConsoleReporter.cs
@@ -32,7 +32,7 @@ namespace TSQLLint.Infrastructure.Reporters
 
         public void ReportResults(TimeSpan timespan, int fileCount)
         {
-            var text = $"\nLinted {fileCount} files in {timespan.TotalSeconds} seconds\n\n{errorCount} Errors.\n{warningCount} Warnings";
+            var text = $"\nLinted {fileCount} files in {timespan.TotalSeconds} seconds\n\n{errorCount} Errors.\n{warningCount} Warnings.";
             if (FixedCount > 0)
             {
                 text += $"\n{FixedCount} Fixed";

--- a/source/TSQLLint.Tests/UnitTests/Reporter/ReporterTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/Reporter/ReporterTests.cs
@@ -30,7 +30,7 @@ namespace TSQLLint.Tests.UnitTests.Reporter
             reporter.Received().Report("foo.sql(1,2): error rule name : rule text.");
             reporter.Received().Report("foo.sql(1,3): warning rule name : rule text.");
             reporter.DidNotReceive().Report("foo.sql(1,3): off rule name : rule text.");
-            reporter.Received().Report("\nLinted 1 files in 3661 seconds\n\n2 Errors.\n1 Warnings");
+            reporter.Received().Report("\nLinted 1 files in 3661 seconds\n\n2 Errors.\n1 Warnings.");
         }
     }
 }


### PR DESCRIPTION
The Errors line item ends in a period, the Warnings probably should too.

Current output:
```
0 Errors.
0 Warnings
```

Expected:
```
0 Errors.
0 Warnings.
```