### PR TITLE
Add support for ignore list file.

### DIFF
--- a/source/TSQLLint.Core/Interfaces/ICommandLineOptions.cs
+++ b/source/TSQLLint.Core/Interfaces/ICommandLineOptions.cs
@@ -8,6 +8,8 @@ namespace TSQLLint.Core.Interfaces
 
         string ConfigFile { get; set; }
 
+        string IgnoreListFile { get; set; }
+
         bool Fix { get; set; }
 
         bool Force { get; set; }

--- a/source/TSQLLint.Core/Interfaces/IGlobPatternMatcher.cs
+++ b/source/TSQLLint.Core/Interfaces/IGlobPatternMatcher.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TSQLLint.Core.Interfaces
+{
+    public interface IGlobPatternMatcher
+    {
+        IEnumerable<string> GetResultsInFullPath(string path);
+    }
+}

--- a/source/TSQLLint.Core/Interfaces/IIgnoreListReader.cs
+++ b/source/TSQLLint.Core/Interfaces/IIgnoreListReader.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TSQLLint.Common;
+using TSQLLint.Core.Interfaces;
+
+namespace TSQLLint.Core.Interfaces
+{
+    public interface IIgnoreListReader
+    {
+        public IEnumerable<string> IgnoreList { get; }
+
+        public bool IsIgnoreListLoaded { get; }
+
+        public void LoadIgnoreList(string path);
+    }
+}

--- a/source/TSQLLint.Infrastructure/CommandLineOptions/CommandLineOptions.cs
+++ b/source/TSQLLint.Infrastructure/CommandLineOptions/CommandLineOptions.cs
@@ -23,6 +23,13 @@ namespace TSQLLint.Infrastructure.CommandLineOptions
         public string ConfigFile { get; set; }
 
         [Option(
+            'g',
+             longName: "ignorelist",
+             Required = false,
+             HelpText = "Used to specify a .tsqllintignore file path other than the default")]
+        public string IgnoreListFile { get; set; }
+
+        [Option(
             'f',
             longName: "force",
             Required = false,

--- a/source/TSQLLint.Infrastructure/Configuration/IgnoreListReader.cs
+++ b/source/TSQLLint.Infrastructure/Configuration/IgnoreListReader.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TSQLLint.Common;
+using TSQLLint.Core.Interfaces;
+
+namespace TSQLLint.Infrastructure.Configuration
+{
+    public class IgnoreListReader : IIgnoreListReader
+    {
+        public IEnumerable<string> IgnoreList { get; private set; }
+
+        private readonly IReporter reporter;
+
+        private readonly IFileSystem fileSystem;
+
+        private readonly IEnvironmentWrapper environmentWrapper;
+
+        public IgnoreListReader(IReporter reporter)
+            : this(reporter, new FileSystem(), new EnvironmentWrapper()) { }
+
+        public IgnoreListReader(IReporter reporter, IFileSystem fileSystem, IEnvironmentWrapper environmentWrapper)
+        {
+            this.reporter = reporter;
+            this.fileSystem = fileSystem;
+            this.environmentWrapper = environmentWrapper;
+        }
+
+        public bool IsIgnoreListLoaded { get; private set; } = false;
+
+        public void LoadIgnoreList(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                var envVariableIgnoreListFilePath = environmentWrapper.GetEnvironmentVariable("tsqllintignore");
+
+                if (!string.IsNullOrWhiteSpace(envVariableIgnoreListFilePath))
+                {
+                    if (fileSystem.File.Exists(envVariableIgnoreListFilePath))
+                    {
+                        LoadIgnoreListFromFile(envVariableIgnoreListFilePath);
+                        return;
+                    }
+                }
+
+                var localIgnoreListFilePath = fileSystem.Path.Combine(Environment.CurrentDirectory, @".tsqllintignore");
+                if (fileSystem.File.Exists(localIgnoreListFilePath))
+                {
+                    LoadIgnoreListFromFile(localIgnoreListFilePath);
+                    return;
+                }
+
+                var defaultIgnoreListFilePath = fileSystem.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), @".tsqllintignore");
+                if (fileSystem.File.Exists(defaultIgnoreListFilePath))
+                {
+                    LoadIgnoreListFromFile(defaultIgnoreListFilePath);
+                    return;
+                }
+
+                IgnoreList = Enumerable.Empty<string>();
+                IsIgnoreListLoaded = true;
+            }
+            else
+            {
+                if (fileSystem.File.Exists(path))
+                {
+                    LoadIgnoreListFromFile(path);
+                    return;
+                }
+                else
+                {
+                    reporter.Report($@"Config file not found: {path}");
+                    IgnoreList = Enumerable.Empty<string>();
+                }
+            }
+        }
+
+        void LoadIgnoreListFromFile(string path)
+        {
+            IgnoreList = fileSystem.File.ReadAllLines(path).Where(line => !string.IsNullOrWhiteSpace(line)).Select(line => line.Trim());
+            IsIgnoreListLoaded = true;
+        }
+    }
+}

--- a/source/TSQLLint.Infrastructure/Parser/GlobPatternMatcher.cs
+++ b/source/TSQLLint.Infrastructure/Parser/GlobPatternMatcher.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.Extensions.FileSystemGlobbing.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TSQLLint.Core.Interfaces;
+
+namespace TSQLLint.Infrastructure.Parser
+{
+    public class GlobPatternMatcher : IGlobPatternMatcher
+    {
+        private readonly Matcher matcher = new Matcher();
+
+        public GlobPatternMatcher(Matcher matcher)
+        {
+            this.matcher = matcher;
+        }
+
+        public IEnumerable<string> GetResultsInFullPath(string path)
+        {
+            return matcher.GetResultsInFullPath(path);
+        }
+    }
+}

--- a/source/TSQLLint.Infrastructure/TSQLLint.Infrastructure.csproj
+++ b/source/TSQLLint.Infrastructure/TSQLLint.Infrastructure.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="160.5400.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="TSQLLint.Common" Version="3.3.0" />

--- a/source/TSQLLint.Tests/FunctionalTests/.tsqllintignore
+++ b/source/TSQLLint.Tests/FunctionalTests/.tsqllintignore
@@ -1,0 +1,6 @@
+invalid-syntax.sql
+with-errors.sql
+with-fixable-errors.sql
+with-fixable-errors*.sql
+IgnoreFolder1/*.sql
+IgnoreFolder2/**/*.sql

--- a/source/TSQLLint.Tests/FunctionalTests/TestFiles/IgnoreFolder1/ignored-file1.sql
+++ b/source/TSQLLint.Tests/FunctionalTests/TestFiles/IgnoreFolder1/ignored-file1.sql
@@ -1,0 +1,1 @@
+SELECT * FROM BAR

--- a/source/TSQLLint.Tests/FunctionalTests/TestFiles/IgnoreFolder1/ignored-file2.sql
+++ b/source/TSQLLint.Tests/FunctionalTests/TestFiles/IgnoreFolder1/ignored-file2.sql
@@ -1,0 +1,1 @@
+SELECT FOO FROM dbo.BAR;

--- a/source/TSQLLint.Tests/FunctionalTests/TestFiles/IgnoreFolder2/IgnoreSubFolder/ignored-file3.sql
+++ b/source/TSQLLint.Tests/FunctionalTests/TestFiles/IgnoreFolder2/IgnoreSubFolder/ignored-file3.sql
@@ -1,0 +1,1 @@
+SELECT FOO FROM dbo.BAR;

--- a/source/TSQLLint.Tests/TSQLLint.Tests.csproj
+++ b/source/TSQLLint.Tests/TSQLLint.Tests.csproj
@@ -42,7 +42,7 @@
     <Content Include="UnitTests\**\*.sql;UnitTests\**\*.dll;UnitTests\**\*.tsqllintrc*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="FunctionalTests\**\*.sql;FunctionalTests\**\*.dll;FunctionalTests\**\*.tsqllintrc*">
+    <Content Include="FunctionalTests\**\*.sql;FunctionalTests\**\*.dll;FunctionalTests\**\*.tsqllintrc*;FunctionalTests\**\*.tsqllintignore*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/source/TSQLLint.Tests/UnitTests/ConfigFile/IgnoreListReaderTest.cs
+++ b/source/TSQLLint.Tests/UnitTests/ConfigFile/IgnoreListReaderTest.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using NSubstitute;
+using NUnit.Framework;
+using TSQLLint.Common;
+using TSQLLint.Core.Interfaces;
+using TSQLLint.Infrastructure.Configuration;
+using TSQLLint.Tests.Helpers;
+using static System.String;
+
+namespace TSQLLint.Tests.UnitTests.ConfigFile
+{
+    [TestFixture]
+    public class IgnoreListReaderTest
+    {
+        [Test]
+        public void IgnoreListReaderEmptyPath()
+        {
+            // arrange
+            var fileSystem = new MockFileSystem();
+            var reporter = Substitute.For<IReporter>();
+            var environmentWrapper = Substitute.For<IEnvironmentWrapper>();
+
+            // act
+            var ignoreListReader = new IgnoreListReader(reporter, fileSystem, environmentWrapper);
+            ignoreListReader.LoadIgnoreList(Empty);
+
+            // assert
+            Assert.IsTrue(ignoreListReader.IsIgnoreListLoaded);
+            CollectionAssert.AreEqual(ignoreListReader.IgnoreList, new List<string>());
+        }
+
+        [Test]
+        public void IgnoreListReaderInMemoryList()
+        {
+            // arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var reporter = Substitute.For<IReporter>();
+            var environmentWrapper = Substitute.For<IEnvironmentWrapper>();
+
+            // act
+            var ignoreListReader = new IgnoreListReader(reporter, fileSystem, environmentWrapper);
+            ignoreListReader.LoadIgnoreList(Empty);
+
+            // assert
+            Assert.IsTrue(ignoreListReader.IsIgnoreListLoaded);
+            CollectionAssert.AreEqual(ignoreListReader.IgnoreList, new List<string>());
+        }
+
+        [Test]
+        public void IgnoreListReaderFileDoesntExist()
+        {
+            // arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var reporter = Substitute.For<IReporter>();
+            var environmentWrapper = Substitute.For<IEnvironmentWrapper>();
+
+            // act
+            var ignoreListReader = new IgnoreListReader(reporter, fileSystem, environmentWrapper);
+            ignoreListReader.LoadIgnoreList(TestHelper.GetTestFilePath(@"c:\users\someone\.tsqllintignore"));
+
+            // assert
+            Assert.IsFalse(ignoreListReader.IsIgnoreListLoaded);
+            CollectionAssert.AreEqual(ignoreListReader.IgnoreList, new List<string>());
+        }
+
+        [Test]
+        public void IgnoreListReaderFromUserProfile()
+        {
+            // arrange
+            var ignoreListFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), @".tsqllintignore");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    ignoreListFilePath, new MockFileData(@"
+                        test1.sql
+                        test2.sql
+                    ")
+                }
+            });
+
+            var reporter = Substitute.For<IReporter>();
+            var environmentWrapper = Substitute.For<IEnvironmentWrapper>();
+
+            // act
+            var ignoreListReader = new IgnoreListReader(reporter, fileSystem, environmentWrapper);
+            ignoreListReader.LoadIgnoreList(null);
+
+            // assert
+            Assert.IsTrue(ignoreListReader.IsIgnoreListLoaded);
+            CollectionAssert.AreEqual(ignoreListReader.IgnoreList, new List<string> { "test1.sql", "test2.sql" });
+        }
+
+        [Test]
+        public void IgnoreListReaderFromLocal()
+        {
+            // arrange
+            var localConfigFile = Path.Combine(TestContext.CurrentContext.TestDirectory, ".tsqllintignore");
+            var fileSystem = new MockFileSystem(
+            new Dictionary<string, MockFileData>
+            {
+                {
+                    // should ignore config files in user profile when local config exists
+                    TestHelper.GetTestFilePath(@"C:\Users\User\.tsqllintignore"), new MockFileData(@"
+                        test1.sql
+                        test2.sql
+                    ")
+                },
+                {
+                    localConfigFile, new MockFileData(@"
+                        test3.sql
+                        test4.sql
+                ")
+                }
+            }, TestContext.CurrentContext.TestDirectory);
+
+            var reporter = Substitute.For<IReporter>();
+            var environmentWrapper = Substitute.For<IEnvironmentWrapper>();
+
+            // act
+            var ignoreListReader = new IgnoreListReader(reporter, fileSystem, environmentWrapper);
+            ignoreListReader.LoadIgnoreList(null);
+
+            // assert
+            Assert.IsTrue(ignoreListReader.IsIgnoreListLoaded);
+            CollectionAssert.AreEqual(ignoreListReader.IgnoreList, new List<string> { "test3.sql", "test4.sql" });
+        }
+
+        [Test]
+        public void ConfigReaderLoadsConfigsEnvironmentVariable()
+        {
+            // arrange
+            var testConfigFile = TestHelper.GetTestFilePath(@"c:\foo\.tsqllintignore");
+
+            var fileSystem = new MockFileSystem(
+                new Dictionary<string, MockFileData>
+                {
+                    {
+                        // should ignore config files in user profile when local config exists
+                        testConfigFile, new MockFileData(@"
+                            test1.sql
+                            test2.sql
+                        ")
+                    },
+                    {
+                        // should ignore config files in user profile when local config exists
+                        TestHelper.GetTestFilePath(@"C:\Users\User\.tsqllintignore"), new MockFileData(@"
+                            test3.sql
+                            test4.sql
+                        ")
+                    },
+                }, TestContext.CurrentContext.TestDirectory);
+
+            var reporter = Substitute.For<IReporter>();
+            var environmentWrapper = Substitute.For<IEnvironmentWrapper>();
+            environmentWrapper.GetEnvironmentVariable("tsqllintignore").Returns(testConfigFile);
+
+            // act
+            var ignoreListReader = new IgnoreListReader(reporter, fileSystem, environmentWrapper);
+            ignoreListReader.LoadIgnoreList(null);
+
+            // assert
+            Assert.IsTrue(ignoreListReader.IsIgnoreListLoaded);
+            CollectionAssert.AreEqual(new List<string> { "test1.sql", "test2.sql" }, ignoreListReader.IgnoreList);
+        }
+    }
+}

--- a/source/TSQLLint.Tests/UnitTests/Parser/SqlFileProcessorTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/Parser/SqlFileProcessorTests.cs
@@ -77,7 +77,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             });
 
             var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
-            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts").Returns(new[] { filePath1, filePath3, filePath4 });
+            globPatternMatcher.GetResultsInFullPath(TestHelper.GetTestFilePath(@"c:\dbscripts")).Returns(new[] { filePath1, filePath3, filePath4 });
 
             // act
             processor.ProcessPath(TestHelper.GetTestFilePath(@"c:\dbscripts"));
@@ -121,7 +121,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             });
 
             var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
-            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts").Returns(new[] { filePath1, filePath2, filePath3, filePath4 });
+            globPatternMatcher.GetResultsInFullPath(TestHelper.GetTestFilePath(@"c:\dbscripts")).Returns(new[] { filePath1, filePath2, filePath3, filePath4 });
 
             // act
             processor.ProcessPath(TestHelper.GetTestFilePath(@"c:\dbscripts"));
@@ -422,8 +422,8 @@ namespace TSQLLint.Tests.UnitTests.Parser
             });
 
             var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
-            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts\db1\").Returns(new[] { filePath2 });
-            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts\db2\sproc").Returns(new[] { filePath4 });
+            globPatternMatcher.GetResultsInFullPath(TestHelper.GetTestFilePath(@"c:\dbscripts\db1\")).Returns(new[] { filePath2 });
+            globPatternMatcher.GetResultsInFullPath(TestHelper.GetTestFilePath(@"c:\dbscripts\db2\sproc")).Returns(new[] { filePath4 });
 
             var f1 = TestHelper.GetTestFilePath(@"c:\dbscripts\db2\sproc");
             var f2 = TestHelper.GetTestFilePath(@"c:\dbscripts\db2\file3.sql");
@@ -469,7 +469,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             });
 
             var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
-            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts\db1\").Returns(new[] { filePath1, filePath2 });
+            globPatternMatcher.GetResultsInFullPath(TestHelper.GetTestFilePath(@"c:\dbscripts\db1\")).Returns(new[] { filePath1, filePath2 });
 
             // act
             processor.ProcessList(new List<string> { invalidFilePath, TestHelper.GetTestFilePath(@"c:\dbscripts\db1\") });

--- a/source/TSQLLint.Tests/UnitTests/Parser/SqlFileProcessorTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/Parser/SqlFileProcessorTests.cs
@@ -29,7 +29,8 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var fileSystem = Substitute.For<IFileSystem>();
             var fileBase = Substitute.For<FileBase>();
             var pluginHandler = Substitute.For<IPluginHandler>();
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
 
             fileBase.Exists(filePath).Returns(true);
             fileBase.OpenRead(filePath).Returns(ParsingUtility.GenerateStreamFromString("Some Sql To Parse"));
@@ -41,7 +42,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             // assert
             fileBase.Received().Exists(filePath);
             fileBase.Received().OpenRead(filePath);
-            ruleVisitor.Received().VisitRules(filePath, Arg.Any<IEnumerable<IExtendedRuleException>>(),  Arg.Any<Stream>());
+            ruleVisitor.Received().VisitRules(filePath, Arg.Any<IEnumerable<IExtendedRuleException>>(), Arg.Any<Stream>());
             Assert.AreEqual(1, processor.FileCount);
         }
 
@@ -57,6 +58,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var pluginHandler = Substitute.For<IPluginHandler>();
             var reporter = Substitute.For<IReporter>();
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -74,7 +76,8 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
+            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts").Returns(new[] { filePath1, filePath3, filePath4 });
 
             // act
             processor.ProcessPath(TestHelper.GetTestFilePath(@"c:\dbscripts"));
@@ -99,6 +102,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -116,7 +120,8 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
+            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts").Returns(new[] { filePath1, filePath2, filePath3, filePath4 });
 
             // act
             processor.ProcessPath(TestHelper.GetTestFilePath(@"c:\dbscripts"));
@@ -140,6 +145,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var fileSystem = Substitute.For<IFileSystem>();
             var fileBase = Substitute.For<FileBase>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             fileBase.Exists(filePath).Returns(false);
             fileSystem.File.Returns(fileBase);
@@ -147,7 +153,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             directoryBase.Exists(filePath).Returns(false);
             fileSystem.Directory.Returns(directoryBase);
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
 
             // act
             processor.ProcessPath(filePath);
@@ -168,6 +174,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var filePath2 = TestHelper.GetTestFilePath(@"c:\dbscripts\file2.txt");
             var filePath3 = TestHelper.GetTestFilePath(@"c:\dbscripts\file3.sql");
             var filePath4 = TestHelper.GetTestFilePath(@"c:\dbscripts\file4.Sql");
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
@@ -189,7 +196,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
 
             // act
             processor.ProcessPath(TestHelper.GetTestFilePath(@"c:\dbscripts\file?.sql"));
@@ -215,6 +222,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -235,7 +243,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
 
             // act
             processor.ProcessPath(TestHelper.GetTestFilePath(@"c:\dbscripts\file*.*"));
@@ -258,6 +266,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             var fileSystem = new MockFileSystem(
                 new Dictionary<string, MockFileData>
@@ -268,7 +277,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 },
                 TestHelper.GetTestFilePath(@"c:\dbscripts"));
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
 
             // act
             processor.ProcessPath(TestHelper.GetTestFilePath(@"c:\doesntExist\file*.*"));
@@ -292,6 +301,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             var fileSystem = new MockFileSystem(
                 new Dictionary<string, MockFileData>
@@ -313,7 +323,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                     }
                 }, TestHelper.GetTestFilePath(@"c:\dbscripts"));
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
 
             // act
             processor.ProcessPath(@"file*.*");
@@ -341,6 +351,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -349,7 +360,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
 
             // act
             processor.ProcessPath(TestHelper.GetTestFilePath(@"c:\dbscripts\invalid*.*"));
@@ -368,7 +379,9 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var reporter = Substitute.For<IReporter>();
             var fileSystem = Substitute.For<IFileSystem>();
             var pluginHandler = Substitute.For<IPluginHandler>();
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
+
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
 
             // act
             processor.ProcessList(new List<string>());
@@ -390,6 +403,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -407,7 +421,9 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
+            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts\db1\").Returns(new[] { filePath2 });
+            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts\db2\sproc").Returns(new[] { filePath4 });
 
             var f1 = TestHelper.GetTestFilePath(@"c:\dbscripts\db2\sproc");
             var f2 = TestHelper.GetTestFilePath(@"c:\dbscripts\db2\file3.sql");
@@ -440,6 +456,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
             var ruleVisitor = Substitute.For<IRuleVisitor>();
             var reporter = Substitute.For<IReporter>();
             var pluginHandler = Substitute.For<IPluginHandler>();
+            var globPatternMatcher = Substitute.For<IGlobPatternMatcher>();
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -451,7 +468,8 @@ namespace TSQLLint.Tests.UnitTests.Parser
                 }
             });
 
-            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList);
+            var processor = new SqlFileProcessor(ruleVisitor, pluginHandler, reporter, fileSystem, ruleList, globPatternMatcher);
+            globPatternMatcher.GetResultsInFullPath(@"c:\dbscripts\db1\").Returns(new[] { filePath1, filePath2 });
 
             // act
             processor.ProcessList(new List<string> { invalidFilePath, TestHelper.GetTestFilePath(@"c:\dbscripts\db1\") });


### PR DESCRIPTION
As #262  mentioned, is is useful to ignore some files in a folder. I added support for .tsqllintignore files, it will only be applied to those paths that point to a folder. I used [Microsoft.Extensions.FileSystemGlobbing](https://www.nuget.org/packages/Microsoft.Extensions.FileSystemGlobbing) to handle the glob pattern.