### PR TITLE
add-get-rules-plugin-tests - Added functional test for plugin rule loading and running

### DIFF
--- a/source/TSQLLint.Tests/FunctionalTests/.tsqllintrc-plugins
+++ b/source/TSQLLint.Tests/FunctionalTests/.tsqllintrc-plugins
@@ -3,7 +3,7 @@
     "schema-qualify": "off",
     "select-star": "warning",
     "semicolon-termination": "error",
-    "plugin-rule": "error"
+    "no-comments": "warning"
   },
   "plugins": {
     "test-plugin": "changeme"

--- a/source/TSQLLint.Tests/FunctionalTests/ConsoleAppTests.cs
+++ b/source/TSQLLint.Tests/FunctionalTests/ConsoleAppTests.cs
@@ -119,6 +119,7 @@ namespace TSQLLint.Tests.FunctionalTests
 
         [TestCase(@"TestFiles/with-tabs.sql", "prefer-tabs : Should use spaces rather than tabs", 0)]
         [TestCase(@"TestFiles/with-spaces.sql", "Loaded plugin: 'TSQLLint.Tests.UnitTests.PluginHandler.TestPlugin'", 0)]
+        [TestCase(@"TestFiles/with-comment.sql", "no-comments : Should not have comments", 0)]
         public void LoadPluginTest(string testFile, string expectedMessage, int expectedExitCode)
         {
             var pluginLoaded = false;
@@ -196,7 +197,7 @@ namespace TSQLLint.Tests.FunctionalTests
             File.Delete(updatedConfigFilePath);
         }
 
-        [TestCase(6, 0)]
+        [TestCase(7, 0)]
         public void LintingFilesWithIgnoreListTest(int expectedFileCount, int expectedExitCode)
         {
             var passed = false;

--- a/source/TSQLLint.Tests/FunctionalTests/TestFiles/with-comment.sql
+++ b/source/TSQLLint.Tests/FunctionalTests/TestFiles/with-comment.sql
@@ -1,0 +1,5 @@
+-- I am a comment.
+IF 1=1
+BEGIN
+    SELECT FOO FROM dbo.BAR;
+END

--- a/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPlugin.cs
+++ b/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPlugin.cs
@@ -33,7 +33,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
 
         public IDictionary<string, ISqlLintRule> GetRules() => new Dictionary<string, ISqlLintRule>
         {
-            ["plugin-rule"] = new TestPluginRule(null)
+            ["no-comments"] = new TestPluginRule(null)
         };
     }
 }

--- a/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPluginRule.cs
+++ b/source/TSQLLint.Tests/UnitTests/PluginHandler/TestPluginRule.cs
@@ -16,11 +16,25 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
             this.errorCallback = errorCallback;
         }
 
-        public string RULE_NAME => "plugin-rule";
+        public string RULE_NAME => "no-comments";
 
-        public string RULE_TEXT => "Plugin rule failed";
+        public string RULE_TEXT => "Should not have comments";
 
         public RuleViolationSeverity RULE_SEVERITY => RuleViolationSeverity.Error;
+
+        public override void Visit(TSqlScript node)
+        {
+            foreach (var token in node.ScriptTokenStream)
+            {
+                if (token.TokenType != TSqlTokenType.SingleLineComment)
+                {
+                    continue;
+                }
+
+                errorCallback(RULE_NAME, RULE_TEXT, token.Line, token.Column);
+                break;
+            }
+        }
 
         public void FixViolation(List<string> fileLines, IRuleViolation ruleViolation, FileLineActions actions)
         {


### PR DESCRIPTION
- Added functional test for plugin rule loading and running.
- Also tests overridability of default plugin rule severity in `.tsqllintrc` files.