### PR TITLE
Switch to LoadFrom rather than LoadFile to allow dependency loading

### DIFF
--- a/source/TSQLLint.Core/Interfaces/IAssemblyWrapper.cs
+++ b/source/TSQLLint.Core/Interfaces/IAssemblyWrapper.cs
@@ -5,7 +5,7 @@ namespace TSQLLint.Core.Interfaces
 {
     public interface IAssemblyWrapper
     {
-        Assembly LoadFile(string path);
+        Assembly LoadFrom(string path);
 
         Type[] GetExportedTypes(Assembly assembly);
     }

--- a/source/TSQLLint.Infrastructure/Plugins/AssemblyWrapper.cs
+++ b/source/TSQLLint.Infrastructure/Plugins/AssemblyWrapper.cs
@@ -6,9 +6,9 @@ namespace TSQLLint.Infrastructure.Plugins
 {
     public class AssemblyWrapper : IAssemblyWrapper
     {
-        public Assembly LoadFile(string path)
+        public Assembly LoadFrom(string path)
         {
-            return Assembly.LoadFile(path);
+            return Assembly.LoadFrom(path);
         }
 
         public Type[] GetExportedTypes(Assembly assembly)

--- a/source/TSQLLint.Infrastructure/Plugins/PluginHandler.cs
+++ b/source/TSQLLint.Infrastructure/Plugins/PluginHandler.cs
@@ -94,7 +94,7 @@ namespace TSQLLint.Infrastructure.Plugins
         public void LoadPlugin(string assemblyPath)
         {
             var path = fileSystem.Path.GetFullPath(assemblyPath);
-            var dll = assemblyWrapper.LoadFile(path);
+            var dll = assemblyWrapper.LoadFrom(path);
 
             foreach (var type in assemblyWrapper.GetExportedTypes(dll))
             {

--- a/source/TSQLLint.Tests/UnitTests/PluginHandler/AssemblyWrapperTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/PluginHandler/AssemblyWrapperTests.cs
@@ -20,7 +20,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
         public void AssemblyWrapper_LoadFile_ShouldLoadTestAssembly()
         {
             var assemblyWrapper = new AssemblyWrapper();
-            var loadedAssembly = assemblyWrapper.LoadFile(AssemblyPath);
+            var loadedAssembly = assemblyWrapper.LoadFrom(AssemblyPath);
 
             Assert.AreEqual("TSQLLint.Tests.dll", loadedAssembly.ManifestModule.ScopeName);
         }
@@ -29,7 +29,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
         public void AssemblyWrapper_GetExportedTypes_ShouldReturnTypes()
         {
             var assemblyWrapper = new AssemblyWrapper();
-            var loadedAssembly = assemblyWrapper.LoadFile(AssemblyPath);
+            var loadedAssembly = assemblyWrapper.LoadFrom(AssemblyPath);
             var loadedTypes = assemblyWrapper.GetExportedTypes(loadedAssembly);
 
             Assert.IsTrue(loadedTypes.Length > 0);

--- a/source/TSQLLint.Tests/UnitTests/PluginHandler/PluginHandlerTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/PluginHandler/PluginHandlerTests.cs
@@ -326,7 +326,7 @@ namespace TSQLLint.Tests.UnitTests.PluginHandler
                 this.defaultPlugin = defaultPlugin ?? typeof(TestPlugin);
             }
 
-            public Assembly LoadFile(string path)
+            public Assembly LoadFrom(string path)
             {
                 assemblyLoaded = path;
                 return assembly;


### PR DESCRIPTION
Uses a more flexible load mechanism for getting plugins, allowing for plugins to have their own dependencies. 