### PR TITLE
Add .NET 7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - checkout
       - run:
           name: build and test
-          command: ./scripts/dotnet_build_test.sh
+          command: ./scripts/dotnet_build_test.sh net7.0
       - store_artifacts:
           path: /artifacts/linux-x64.tgz
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:7.0
     steps:
       - checkout
       - run:
@@ -14,7 +14,7 @@ jobs:
 
   build and notify:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:7.0
     steps:
       - checkout
       - run:
@@ -42,7 +42,7 @@ jobs:
 
   package and push to nuget:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:7.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - run:
           name: build and test
-          command: ./scripts/dotnet_build_test.sh
+          command: ./scripts/dotnet_build_test.sh net7.0
 
   build and notify:
     docker:

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+﻿# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+
+[*.sh]
+end_of_line = lf

--- a/scripts/dotnet_build_test.sh
+++ b/scripts/dotnet_build_test.sh
@@ -49,9 +49,9 @@ command -v reportgenerator >/dev/null 2>&1 || {
     dotnet tool install dotnet-reportgenerator-globaltool --global --version 5.0.2;
 }
 
-info "running test project"
-
 TEST_TARGET_FRAMEWORK=$1
+
+info "running test project on $TEST_TARGET_FRAMEWORK"
 
 dotnet test \
     --no-restore \

--- a/scripts/dotnet_build_test.sh
+++ b/scripts/dotnet_build_test.sh
@@ -51,11 +51,14 @@ command -v reportgenerator >/dev/null 2>&1 || {
 
 info "running test project"
 
+TEST_TARGET_FRAMEWORK=$1
+
 dotnet test \
     --no-restore \
     --collect:"XPlat Code Coverage" \
     --settings "$PROJECT_ROOT/source/coverlet.runsettings" \
     --results-directory "$COVERAGE_DIR" \
+    -property:TargetFramework=$TEST_TARGET_FRAMEWORK \
     "$PROJECT_ROOT/source/TSQLLint.sln"
 
 COVERAGE_FILE="$(find $COVERAGE_DIR -name coverage.opencover.xml)"

--- a/source/.editorconfig
+++ b/source/.editorconfig
@@ -1,9 +1,4 @@
 ﻿# http://editorconfig.org
-root = true
-
-[*]
-charset = utf-8
-end_of_line = crlf
 
 [*.cs]
 indent_style = space

--- a/source/TSQLLint.Core/TSQLLint.Core.csproj
+++ b/source/TSQLLint.Core/TSQLLint.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>./artifacts</PackageOutputPath>
   </PropertyGroup>

--- a/source/TSQLLint.Infrastructure/TSQLLint.Infrastructure.csproj
+++ b/source/TSQLLint.Infrastructure/TSQLLint.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>./artifacts</PackageOutputPath>
   </PropertyGroup>

--- a/source/TSQLLint.Tests/TSQLLint.Tests.csproj
+++ b/source/TSQLLint.Tests/TSQLLint.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/source/TSQLLint/TSQLLint.csproj
+++ b/source/TSQLLint/TSQLLint.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <StartupObject>TSQLLint.Program</StartupObject>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
 
     <ToolCommandName>tsqllint</ToolCommandName>


### PR DESCRIPTION
Add the possibility to run it with .NET 7

We want to upgrade in [MegaLinter](https://github.com/oxsecurity/megalinter) the SDK to .NET 7 but TSQLLint only works with .NET 6.

This PR adds the target to .NET 7 in addition to the existing one (.NET 6).